### PR TITLE
bugfix: for /dev/input/eventN, N can have more than one digit

### DIFF
--- a/lib/fusuma.rb
+++ b/lib/fusuma.rb
@@ -45,7 +45,7 @@ module Fusuma
 
     def extracted_input_device_from(line)
       return unless line =~ /^Kernel: /
-      @device_name = line.match(/event[0-9]/).to_s
+      @device_name = line.match(/event[0-9]+/).to_s
     end
 
     def touch_is_available?(line)


### PR DESCRIPTION
In my case, the trackpad device is event14, but fusuma matches it as event1