### PR TITLE
feature: prevent events from being triggered in quick succession

### DIFF
--- a/lib/fusuma.rb
+++ b/lib/fusuma.rb
@@ -45,7 +45,7 @@ module Fusuma
 
     def extracted_input_device_from(line)
       return unless line =~ /^Kernel: /
-      @device_name = line.match(/event[0-9]/).to_s
+      @device_name = line.match(/event[0-9]+/).to_s
     end
 
     def touch_is_available?(line)

--- a/lib/fusuma.rb
+++ b/lib/fusuma.rb
@@ -13,6 +13,7 @@ module Fusuma
     end
 
     private
+    @@trigger_timeout = Time.new
 
     def read_libinput
       Open3.popen3(libinput_command) do |_i, o, _e, _w|
@@ -20,7 +21,7 @@ module Fusuma
           gesture_action = GestureAction.initialize_by_libinput(line, device_name)
           next if gesture_action.nil?
           @action_stack ||= ActionStack.new
-          @action_stack.push gesture_action
+          @action_stack.push gesture_action unless Time.new < @@trigger_timeout
           gesture_info = @action_stack.gesture_info
           trigger_keyevent(gesture_info) unless gesture_info.nil?
         end
@@ -58,8 +59,10 @@ module Fusuma
       case gesture_info.action
       when 'swipe'
         swipe(gesture_info.finger, gesture_info.direction.move)
+        @@trigger_timeout = Time.new + 0.5
       when 'pinch'
         pinch(gesture_info.direction.pinch)
+        @@trigger_timeout = Time.new + 0.05
       end
     end
 


### PR DESCRIPTION
on my machine (ubuntu 16.10, MBPr) gestures often trigger several times, which makes fusuma almost unusable for certain actions (example: when moving between viewports (swipe left/right), it often triggers 2-3 times). The easiest fix I could come up with is to add a timeout after every trigger during which any recognized actions are discarded. The current timeouts of 0.5s for swipe gestures and 0.05s for pinch gestures work well for me, but might not behave optimally with different hardware.