### PR TITLE
Relax the device name regex

### DIFF
--- a/lib/fusuma.rb
+++ b/lib/fusuma.rb
@@ -45,7 +45,7 @@ module Fusuma
 
     def extracted_input_device_from(line)
       return unless line =~ /^Kernel: /
-      @device_name = line.match(/event[0-9]/).to_s
+      @device_name = line.match(/event[0-9]+/).to_s
     end
 
     def touch_is_available?(line)


### PR DESCRIPTION
As event number can be more than single digit.

Probably closes #3.