### PR TITLE
Added interval options to config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,19 @@ pinch:
 threshold:
   swipe: 1
   pinch: 1
+
+interval:
+  swipe: 0.5
+  pinch: 0.05
 ```
 
 if `shortcut: ` is blank, the swipe/pinch doesn't trigger a keyevent.
 
 `threshold:` is sensitivity to swipe/pinch. Default value is 1.
-if the swipe's threshold change to `0.5`, shorten swipe-length by half
+If the swipe's threshold change to `0.5`, shorten swipe-length by half.
+
+`interval:` is delay between swipes/pinches. Default value is 0.5.
+If the swipe's interval is `0.1`, ignore other swipes for 0.1 seconds after a swipe.
 
 ## Options
 

--- a/lib/fusuma/config.rb
+++ b/lib/fusuma/config.rb
@@ -14,6 +14,10 @@ module Fusuma
         instance.threshold(action_type)
       end
 
+      def interval(action_type)
+        instance.interval(action_type)
+      end
+
       def reload
         instance.reload
       end
@@ -41,6 +45,11 @@ module Fusuma
     def threshold(action_type)
       seek_index = ['threshold', action_type]
       cache(seek_index) { search_config(keymap, seek_index) } || 1
+    end
+
+    def interval(action_type)
+      seek_index = ['interval', action_type]
+      cache(seek_index) { search_config(keymap, seek_index) } || 0.5
     end
 
     private

--- a/lib/fusuma/config.yml
+++ b/lib/fusuma/config.yml
@@ -26,3 +26,7 @@ pinch:
 threshold:
   swipe: 1
   pinch: 1
+
+interval:
+  swipe: 0.5
+  pinch: 0.05

--- a/lib/fusuma/pinch.rb
+++ b/lib/fusuma/pinch.rb
@@ -2,7 +2,6 @@ module Fusuma
   # vector data
   class Pinch
     BASE_THERESHOLD = 0.3
-    INTERVAL_TIME = 0.05
 
     def initialize(diameter)
       @diameter = diameter.to_f
@@ -28,7 +27,7 @@ module Fusuma
 
     def enough_interval?
       return true if first_time?
-      return true if (Time.now - self.class.last_time) > INTERVAL_TIME
+      return true if (Time.now - self.class.last_time) > interval_time
       false
     end
 
@@ -38,6 +37,10 @@ module Fusuma
 
     def threshold
       @threshold ||= BASE_THERESHOLD * Config.threshold('pinch')
+    end
+
+    def interval_time
+      @interval_time ||= Config.interval('pinch')
     end
 
     class << self

--- a/lib/fusuma/swipe.rb
+++ b/lib/fusuma/swipe.rb
@@ -2,7 +2,6 @@ module Fusuma
   # vector data
   class Swipe
     BASE_THERESHOLD = 20
-    INTERVAL_TIME   = 0.5
 
     def initialize(x, y)
       @x = x
@@ -28,7 +27,7 @@ module Fusuma
 
     def enough_interval?
       return true if first_time?
-      return true if (Time.now - self.class.last_time) > INTERVAL_TIME
+      return true if (Time.now - self.class.last_time) > interval_time
       false
     end
 
@@ -38,6 +37,10 @@ module Fusuma
 
     def threshold
       @threshold ||= BASE_THERESHOLD * Config.threshold('swipe')
+    end
+
+    def interval_time
+      @interval_time ||= Config.interval('swipe')
     end
 
     class << self


### PR DESCRIPTION
This is my solution to issue #35. The new config options work the same as the threshold options. The code is the same as that for threshold except that the default is `0.5` instead of `1` and there is no `BASE_INTERVAL` equivalent to `BASE_THERESHOLD`. Lightly tested on a 2014 MacBook Pro with Ubuntu 17.04.