### PR TITLE
Switch to 'libinput debug-events' command

### DIFF
--- a/lib/fusuma.rb
+++ b/lib/fusuma.rb
@@ -50,9 +50,8 @@ module Fusuma
 
     def libinput_command
       return @libinput_command if @libinput_command
-      # NOTE: --enable-dwt means "disable while typing"
       prefix = 'stdbuf -oL --'
-      command = 'libinput-debug-events --enable-dwt'
+      command = 'libinput debug-events'
       device_option = if Device.names.size == 1
                         "--device /dev/input/#{Device.names.first}"
                       end

--- a/lib/fusuma/device.rb
+++ b/lib/fusuma/device.rb
@@ -27,7 +27,7 @@ module Fusuma
       end
 
       def list_devices_logs
-        Open3.popen3('libinput-list-devices') do |_i, o, _e, _w|
+        Open3.popen3('libinput list-devices') do |_i, o, _e, _w|
           return o.to_a
         end
       end

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -8,13 +8,13 @@ module Fusuma
           File.open('spec/lib/libinput-list-devices_magic_trackpad.txt')
         end
         it 'should return array' do
-          allow(Open3).to receive(:popen3).with('libinput-list-devices')
+          allow(Open3).to receive(:popen3).with('libinput list-devices')
                                           .and_return(magic_trackpad_log)
           expect(Device.names.class).to eq Array
         end
 
         it 'should return correct devices' do
-          allow(Open3).to receive(:popen3).with('libinput-list-devices')
+          allow(Open3).to receive(:popen3).with('libinput list-devices')
                                           .and_return(magic_trackpad_log)
           expect(Device.names).to eq %w(event8 event9)
         end
@@ -26,13 +26,13 @@ module Fusuma
         end
 
         it 'should failed with exit' do
-          allow(Open3).to receive(:popen3).with('libinput-list-devices')
+          allow(Open3).to receive(:popen3).with('libinput list-devices')
                                           .and_return(unavailable_log)
           expect { Device.names }.to raise_error(SystemExit)
         end
 
         it 'should failed with printing error log' do
-          allow(Open3).to receive(:popen3).with('libinput-list-devices')
+          allow(Open3).to receive(:popen3).with('libinput list-devices')
                                           .and_return(unavailable_log)
           expect(MultiLogger).to receive(:error)
           expect { Device.names }.to raise_error(SystemExit)


### PR DESCRIPTION
Removed `--enable-dwt` option, as it meaningless for fusuma use case and has side effect. Closes #78.

Libinput deprecates `libinput-debug-events` command, thus moving to `libinput debug-events`. Closes #76.