### PR TITLE
Allows pinches to be used as swipes, Sets up actioncount with misc options

### DIFF
--- a/lib/fusuma/action_stack.rb
+++ b/lib/fusuma/action_stack.rb
@@ -35,14 +35,28 @@ module Fusuma
     def generate_vector(action_type)
       case action_type
       when 'swipe'
-        avg_swipe
+        sum_swipe
       when 'pinch'
-        avg_pinch
+        sum_swipe
       end
     end
 
     def detect_finger
       last.finger
+    end
+
+    def sum_swipe
+      move_x = sum_attrs(:move_x)
+      move_y = sum_attrs(:move_y)
+      Swipe.new(move_x, move_y)
+    end
+
+    def sum_pinch
+      move_x = sum_attrs(:move_x)
+      move_y = sum_attrs(:move_y)
+      diameter = sum_attrs(:zoom)
+      delta_diameter = diameter - first.zoom
+      Pinch.new(move_x, move_y, delta_diameter)
     end
 
     def avg_swipe
@@ -52,9 +66,11 @@ module Fusuma
     end
 
     def avg_pinch
+      move_x = avg_attrs(:move_x)
+      move_y = avg_attrs(:move_y)
       diameter = avg_attrs(:zoom)
       delta_diameter = diameter - first.zoom
-      Pinch.new(delta_diameter)
+      Pinch.new(move_x, move_y, delta_diameter)
     end
 
     def sum_attrs(attr)
@@ -77,7 +93,7 @@ module Fusuma
     end
 
     def enough_actions?
-      length > 2
+      length >= if Config.misc('actioncount') != false then Config.misc('actioncount') else 2 end
     end
 
     def enough_elapsed_time?

--- a/lib/fusuma/action_stack.rb
+++ b/lib/fusuma/action_stack.rb
@@ -33,11 +33,21 @@ module Fusuma
     end
 
     def generate_vector(action_type)
-      case action_type
-      when 'swipe'
-        sum_swipe
-      when 'pinch'
-        sum_swipe
+      case Config.misc('calc') ? Config.misc('calc') : 'avg'
+      when 'sum' 
+        case action_type
+        when 'swipe'
+          sum_swipe
+        when 'pinch'
+          sum_swipe
+        end
+      when 'avg'
+        case action_type
+        when 'swipe'
+          avg_swipe
+        when 'pinch'
+          avg_swipe
+        end
       end
     end
 

--- a/lib/fusuma/config.rb
+++ b/lib/fusuma/config.rb
@@ -22,6 +22,10 @@ module Fusuma
         instance.interval(action_type)
       end
 
+      def misc(value)
+        instance.misc(value)
+      end
+
       def reload
         instance.reload
       end
@@ -50,7 +54,7 @@ module Fusuma
       seek_index = [*action_index(event_trigger), 'shortcut']
       cache(seek_index) { search_config(keymap, seek_index) }
     end
-
+    
     def threshold(action_type)
       seek_index = ['threshold', action_type]
       cache(seek_index) { search_config(keymap, seek_index) } || 1
@@ -61,6 +65,11 @@ module Fusuma
       cache(seek_index) { search_config(keymap, seek_index) } || 1
     end
 
+    def misc(value)
+      seek_index = ['misc', value]
+      cache(seek_index) { search_config(keymap, seek_index) } || false
+    end
+    
     private
 
     def search_config(keymap_node, seek_index)

--- a/lib/fusuma/config.yml
+++ b/lib/fusuma/config.yml
@@ -30,3 +30,6 @@ threshold:
 interval:
   swipe: 1
   pinch: 1
+
+misc:
+  actioncount: 1

--- a/lib/fusuma/config.yml
+++ b/lib/fusuma/config.yml
@@ -32,4 +32,5 @@ interval:
   pinch: 1
 
 misc:
+  calc: 'sum'
   actioncount: 1

--- a/lib/fusuma/pinch.rb
+++ b/lib/fusuma/pinch.rb
@@ -3,24 +3,36 @@ module Fusuma
   class Pinch
     BASE_THERESHOLD = 0.3
     BASE_INTERVAL   = 0.05
+    BASE_SWIPE_THERESHOLD = 20
+    BASE_SWIPE_INTERVAL   = 0.5
 
-    def initialize(diameter)
+    def initialize(x,y,diameter)
       @diameter = diameter.to_f
+      @x = x
+      @y = y
     end
 
     attr_reader :diameter
 
     def direction
-      return 'in' if diameter > 0
+      return x > 0 ? 'right' : 'left' if enough_distance? && x.abs > y.abs
+      y > 0 ? 'down' : 'up' if enough_distance?
+      'in' if diameter > 0
       'out'
     end
 
     def enough?
+      MultiLogger.debug(x: x, y: y)
+      MultiLogger.debug(edist: enough_distance?,etime: enough_interval?)
       MultiLogger.debug(diameter: diameter)
-      enough_diameter? && enough_interval? && self.class.touch_last_time
+      (enough_diameter? && enough_interval? && self.class.touch_last_time) || (enough_distance? && enough_interval? && self.class.touch_last_time)
     end
-
+    
     private
+
+    def enough_distance?
+      (x.abs > dist_threshold) || (y.abs > dist_threshold)
+    end
 
     def enough_diameter?
       diameter.abs > threshold
@@ -35,6 +47,16 @@ module Fusuma
     def first_time?
       self.class.last_time.nil?
     end
+
+
+    def dist_threshold
+      @dist_threshold ||= BASE_SWIPE_THERESHOLD * Config.threshold('swipe')
+    end
+
+    def dist_interval_time
+      @dist_interval_time ||= BASE_SWIPE_INTERVAL * Config.interval('swipe')
+    end
+
 
     def threshold
       @threshold ||= BASE_THERESHOLD * Config.threshold('pinch')

--- a/lib/fusuma/swipe.rb
+++ b/lib/fusuma/swipe.rb
@@ -17,7 +17,6 @@ module Fusuma
 
     def enough?
       MultiLogger.debug(x: x, y: y)
-      MultiLogger.debug(threshold: threshold)
       MultiLogger.debug(edist: enough_distance?,etime: enough_interval?)
       enough_distance? && enough_interval? && self.class.touch_last_time
     end

--- a/lib/fusuma/swipe.rb
+++ b/lib/fusuma/swipe.rb
@@ -17,6 +17,8 @@ module Fusuma
 
     def enough?
       MultiLogger.debug(x: x, y: y)
+      MultiLogger.debug(threshold: threshold)
+      MultiLogger.debug(edist: enough_distance?,etime: enough_interval?)
       enough_distance? && enough_interval? && self.class.touch_last_time
     end
 


### PR DESCRIPTION
With some trackpads libinput interprets some swipe like gestures as pinch gestures. As swipe gestures are far more common, this allows pinch gestures to be used as swipes as well. 

Allows total distance traveled to be used as the calculation instead of average movement per event type. This makes long term gestures possible.

Allows the number of action events required for a gesture to be registered to be configureable (also makes it a >= instead of simply >) On some trackpads it is possible for flings to travel a significant distance with only one or two registered events.

In general these changes make the expected swipe gestures on some trackpads much more reliable (at the expense of some pinch gestures).