### PR TITLE
Fix spelling: Elementary to elementary

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ mkdir -p ~/.config/fusuma        # create config directory
 $ nano ~/.config/fusuma/config.yml # edit config file.
 ```
 
-### Example (Gesture Mapping for Elementary OS)
+### Example (Gesture Mapping for elementary OS)
 
 ```yaml
 swipe:


### PR DESCRIPTION
This might just a tiny thing, but [they say](https://elementary.io/brand):

> elementary is always lower-case, even when beginning sentences such as this.
