### PR TITLE
Interval and threshold specific for a trigger

### DIFF
--- a/lib/fusuma/action_stack.rb
+++ b/lib/fusuma/action_stack.rb
@@ -10,11 +10,12 @@ module Fusuma
     def generate_event_trigger
       return unless enough_actions?
       action_type = detect_action_type
-      direction = detect_direction(action_type)
-      return if direction.nil?
+      vector = generate_vector(action_type)
       finger = detect_finger
+      trigger = EventTrigger.new(finger, vector.direction, action_type)
+      return unless vector.enough?(trigger)
       clear
-      EventTrigger.new(finger, direction, action_type)
+      trigger
     end
 
     def push(gesture_action)
@@ -24,12 +25,6 @@ module Fusuma
     alias << push
 
     private
-
-    def detect_direction(action_type)
-      vector = generate_vector(action_type)
-      return if vector && !vector.enough?
-      vector.direction
-    end
 
     def generate_vector(action_type)
       case action_type

--- a/lib/fusuma/action_stack.rb
+++ b/lib/fusuma/action_stack.rb
@@ -12,7 +12,6 @@ module Fusuma
       action_type = detect_action_type
       direction = detect_direction(action_type)
       return if direction.nil?
-      @last_triggered_time = last.time
       finger = detect_finger
       clear
       EventTrigger.new(finger, direction, action_type)
@@ -83,10 +82,6 @@ module Fusuma
     def enough_elapsed_time?
       return false if length.zero?
       (last.time - first.time) > ELAPSED_TIME
-    end
-
-    def last_triggered_time
-      @last_triggered_time ||= 0
     end
 
     def detect_action_type

--- a/lib/fusuma/config.rb
+++ b/lib/fusuma/config.rb
@@ -14,12 +14,12 @@ module Fusuma
         instance.shortcut(event_trigger)
       end
 
-      def threshold(action_type)
-        instance.threshold(action_type)
+      def threshold(action_type, event_trigger)
+        instance.threshold(action_type, event_trigger)
       end
 
-      def interval(action_type)
-        instance.interval(action_type)
+      def interval(action_type, event_trigger)
+        instance.interval(action_type, event_trigger)
       end
 
       def reload
@@ -43,25 +43,33 @@ module Fusuma
 
     def command(event_trigger)
       seek_index = [*action_index(event_trigger), 'command']
-      cache(seek_index) { search_config(keymap, seek_index) }
+      search_config_cached(seek_index)
     end
 
     def shortcut(event_trigger)
       seek_index = [*action_index(event_trigger), 'shortcut']
-      cache(seek_index) { search_config(keymap, seek_index) }
+      search_config_cached(seek_index)
     end
 
-    def threshold(action_type)
-      seek_index = ['threshold', action_type]
-      cache(seek_index) { search_config(keymap, seek_index) } || 1
+    def threshold(action_type, event_trigger)
+      seek_index_trigger = [*action_index(event_trigger), 'threshold']
+      seek_index_global = ['threshold', action_type]
+      search_config_cached(seek_index_trigger) ||
+        search_config_cached(seek_index_global) || 1
     end
 
-    def interval(action_type)
-      seek_index = ['interval', action_type]
-      cache(seek_index) { search_config(keymap, seek_index) } || 1
+    def interval(action_type, event_trigger)
+      seek_index_trigger = [*action_index(event_trigger), 'interval']
+      seek_index_global = ['interval', action_type]
+      search_config_cached(seek_index_trigger) ||
+        search_config_cached(seek_index_global) || 1
     end
 
     private
+
+    def search_config_cached(seek_index)
+      cache(seek_index) { search_config(keymap, seek_index) }
+    end
 
     def search_config(keymap_node, seek_index)
       if seek_index == []

--- a/lib/fusuma/pinch.rb
+++ b/lib/fusuma/pinch.rb
@@ -15,20 +15,21 @@ module Fusuma
       'out'
     end
 
-    def enough?
+    def enough?(trigger)
       MultiLogger.debug(diameter: diameter)
-      enough_diameter? && enough_interval? && self.class.touch_last_time
+      enough_diameter?(trigger) && enough_interval?(trigger) &&
+        self.class.touch_last_time
     end
 
     private
 
-    def enough_diameter?
-      diameter.abs > threshold
+    def enough_diameter?(trigger)
+      diameter.abs > threshold(trigger)
     end
 
-    def enough_interval?
+    def enough_interval?(trigger)
       return true if first_time?
-      return true if (Time.now - self.class.last_time) > interval_time
+      return true if (Time.now - self.class.last_time) > interval_time(trigger)
       false
     end
 
@@ -36,12 +37,12 @@ module Fusuma
       self.class.last_time.nil?
     end
 
-    def threshold
-      @threshold ||= BASE_THERESHOLD * Config.threshold('pinch')
+    def threshold(trigger)
+      @threshold ||= BASE_THERESHOLD * Config.threshold('pinch', trigger)
     end
 
-    def interval_time
-      @interval_time ||= BASE_INTERVAL * Config.interval('pinch')
+    def interval_time(trigger)
+      @interval_time ||= BASE_INTERVAL * Config.interval('pinch', trigger)
     end
 
     class << self

--- a/lib/fusuma/swipe.rb
+++ b/lib/fusuma/swipe.rb
@@ -15,20 +15,21 @@ module Fusuma
       y > 0 ? 'down' : 'up'
     end
 
-    def enough?
+    def enough?(trigger)
       MultiLogger.debug(x: x, y: y)
-      enough_distance? && enough_interval? && self.class.touch_last_time
+      enough_distance?(trigger) && enough_interval?(trigger) &&
+        self.class.touch_last_time
     end
 
     private
 
-    def enough_distance?
-      (x.abs > threshold) || (y.abs > threshold)
+    def enough_distance?(trigger)
+      (x.abs > threshold(trigger)) || (y.abs > threshold(trigger))
     end
 
-    def enough_interval?
+    def enough_interval?(trigger)
       return true if first_time?
-      return true if (Time.now - self.class.last_time) > interval_time
+      return true if (Time.now - self.class.last_time) > interval_time(trigger)
       false
     end
 
@@ -36,12 +37,12 @@ module Fusuma
       self.class.last_time.nil?
     end
 
-    def threshold
-      @threshold ||= BASE_THERESHOLD * Config.threshold('swipe')
+    def threshold(trigger)
+      @threshold ||= BASE_THERESHOLD * Config.threshold('swipe', trigger)
     end
 
-    def interval_time
-      @interval_time ||= BASE_INTERVAL * Config.interval('swipe')
+    def interval_time(trigger)
+      @interval_time ||= BASE_INTERVAL * Config.interval('swipe', trigger)
     end
 
     class << self

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -38,11 +38,37 @@ module Fusuma
       }
     end
 
+    let(:keymap_with_trigger_threshold) do
+      {
+        'swipe' => {
+          3 => {
+            'left' => {
+              'shortcut' => 'alt+Left',
+              'threshold' => 0.8
+            },
+          }
+        }
+      }
+    end
+
     let(:keymap_with_interval) do
       {
         'interval' => {
           'swipe' => 0.3,
           'pinch' => 0.5
+        }
+      }
+    end
+
+    let(:keymap_with_trigger_interval) do
+      {
+        'swipe' => {
+          4 => {
+            'right'  => {
+              'shortcut' => 'alt+Right',
+              'interval' => 0.3
+            },
+          }
         }
       }
     end
@@ -126,7 +152,21 @@ module Fusuma
         end
         it 'should return custom threshold' do
           action_type = 'swipe'
-          expect(Config.threshold(action_type)).to eq 0.5
+          expect(Config.threshold(action_type, event_trigger)).to eq 0.5
+        end
+      end
+
+      context 'when threshold is set on the trigger' do
+        before do
+          allow(YAML).to receive(:load_file).and_return keymap_with_trigger_threshold
+          Config.reload
+          @finger    = 3
+          @action    = 'swipe'
+          @direction = 'left'
+        end
+        it 'should return custom threshold' do
+          action_type = 'swipe'
+          expect(Config.threshold(action_type, event_trigger)).to eq 0.8
         end
       end
 
@@ -137,14 +177,14 @@ module Fusuma
         end
         it 'should return default threshold' do
           action_type = 'swipe'
-          expect(Config.threshold(action_type)).to eq 1
+          expect(Config.threshold(action_type, event_trigger)).to eq 1
         end
       end
 
       context 'with irregular action_type' do
         it 'should return default threshold' do
           action_type = 'missing_property'
-          expect(Config.threshold(action_type)).to eq 1
+          expect(Config.threshold(action_type, event_trigger)).to eq 1
         end
       end
     end
@@ -157,7 +197,21 @@ module Fusuma
         end
         it 'should return custom interval' do
           action_type = 'swipe'
-          expect(Config.interval(action_type)).to eq 0.3
+          expect(Config.interval(action_type, event_trigger)).to eq 0.3
+        end
+      end
+
+      context 'when interval is set on the trigger' do
+        before do
+          allow(YAML).to receive(:load_file).and_return keymap_with_trigger_interval
+          Config.reload
+          @finger    = 4
+          @action    = 'swipe'
+          @direction = 'right'
+        end
+        it 'should return custom interval' do
+          action_type = 'swipe'
+          expect(Config.interval(action_type, event_trigger)).to eq 0.3
         end
       end
 
@@ -168,14 +222,14 @@ module Fusuma
         end
         it 'should return default interval' do
           action_type = 'swipe'
-          expect(Config.threshold(action_type)).to eq 1
+          expect(Config.threshold(action_type, event_trigger)).to eq 1
         end
       end
 
       context 'with irregular action_type' do
         it 'should return default interval' do
           action_type = 'missing_property'
-          expect(Config.threshold(action_type)).to eq 1
+          expect(Config.threshold(action_type, event_trigger)).to eq 1
         end
       end
     end


### PR DESCRIPTION
I want to be able to use this project for controlling the volume on my computer with a 3 finger swipe, so I added the possibility to add a custom interval and threshold for a trigger.

With this code I can setup my config like below and it will be possible to smoothly control the volume on the touchpad.

```
swipe:
  3: 
    left: 
      command: 'xdotool key alt+Left'
    right: 
      command: 'xdotool key alt+Right'
    up: 
      command: 'xdotool key XF86AudioRaiseVolume'
      interval: 0.1
      threshold: 0.1
    down: 
      command: 'xdotool key XF86AudioLowerVolume'
      interval: 0.1
      threshold: 0.1
  4:
    left: 
      command: 'xdotool key ctrl+alt+Up'
    right: 
      command: 'xdotool key ctrl+alt+Down'
    up: 
      command: 'xdotool key super'
    down: 
      command: 'xdotool key super'
pinch:
  in:
#    command: 'xdotool key ctrl+plus'
  out:
#    command: 'xdotool key ctrl+minus'

threshold:
  swipe: 0.1
  pinch: 0.4

interval:
  swipe: 1.0
  pinch: 0.1
```

Let me know what you think. I don't have any experience with Ruby, but I hope it looks good.