### PR TITLE
Merge modifier event records

### DIFF
--- a/lib/fusuma.rb
+++ b/lib/fusuma.rb
@@ -102,7 +102,7 @@ module Fusuma
     end
 
     def filter(event)
-      @filters.reduce(event) { |e, f| f.filter(e) if e }
+      event if @filters.any? { |f| f.filter(event) }
     end
 
     def parse(event)

--- a/lib/fusuma/plugin/buffers/gesture_buffer.rb
+++ b/lib/fusuma/plugin/buffers/gesture_buffer.rb
@@ -16,7 +16,6 @@ module Fusuma
           # - window event buffer
           # - other event buffer
           return if event&.tag != source
-          return if event.record.type != :gesture
 
           @events.push(event)
           clear unless updating?

--- a/lib/fusuma/plugin/events/records/gesture_record.rb
+++ b/lib/fusuma/plugin/events/records/gesture_record.rb
@@ -20,10 +20,6 @@ module Fusuma
             @finger  = finger
             @direction = direction
           end
-
-          def type
-            :gesture
-          end
         end
       end
     end

--- a/lib/fusuma/plugin/events/records/index_record.rb
+++ b/lib/fusuma/plugin/events/records/index_record.rb
@@ -9,6 +9,7 @@ module Fusuma
         class IndexRecord < Record
           # define gesture format
           attr_reader :index
+          attr_reader :position
 
           # @param [Config::Index] index
           # @param [Symbol] position [:prefix, :body, :surfix]
@@ -26,12 +27,12 @@ module Fusuma
           def merge(records:)
             raise "position is NOT body: #{self}" unless mergable?
 
-            @index = records.each_with_object(@index) do |record, merged_index|
+            @index = records.reduce(@index) do |merged_index, record|
               case record.position
               when :prefix
-                Index.new([*record.index.keys, *merged_index.keys])
+                Config::Index.new([*record.index.keys, *merged_index.keys])
               when :surfix
-                Index.new([*merged_index.keys, *record.index.keys])
+                Config::Index.new([*merged_index.keys, *record.index.keys])
               else
                 raise "invalid index position: #{record}"
               end
@@ -42,10 +43,6 @@ module Fusuma
           def mergable?
             @position == :body
           end
-
-          protected
-
-          attr_reader :position
         end
       end
     end

--- a/lib/fusuma/plugin/filters/filter.rb
+++ b/lib/fusuma/plugin/filters/filter.rb
@@ -12,14 +12,11 @@ module Fusuma
         # @return [Event] when keeping event
         # @return [NilClass] when discarding record
         def filter(event)
-          event.tap do |e|
-            next if e.tag != source
-            next if keep?(e.record)
+          return event if event.tag !~ /#{source}/
 
-            MultiLogger.debug(filtered: e)
+          return event if keep?(event.record)
 
-            break nil
-          end
+          nil
         end
 
         # @abstract override `#keep?` to implement

--- a/spec/lib/plugin/events/records/gesture_record_spec.rb
+++ b/spec/lib/plugin/events/records/gesture_record_spec.rb
@@ -15,11 +15,6 @@ module Fusuma
                                 direction: direction)
           end
           let(:direction) { GestureRecord::Delta.new(0, 0, 1, 0) }
-
-          describe '#type' do
-            subject { record.type }
-            it { is_expected.to eq :gesture }
-          end
         end
       end
     end


### PR DESCRIPTION
* Merge event records
  - this feature is required by "https://github.com/iberianpig/fusuma-plugin-keypress".

Merge events
  1. Detect multiple events having `IndexRecord`
  2. Merge **modifier** `IndexRecords` into a **main** `IndexRecord` in events
  3. Return the Event having merged `IndexRecord` 
  4. Pass the Event to `Executor`