### PR TITLE
Implement timeout event 

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -8,5 +8,20 @@ require 'fusuma'
 # with your gem easier. You can also use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
+
+def reload!(print = true)
+  puts 'Reloading ...' if print
+  # Main project directory.
+  root_dir = File.expand_path('..', __dir__)
+  # Directories within the project that should be reloaded.
+  reload_dirs = %w{lib}
+  # Loop through and reload every file in all relevant project directories.
+  reload_dirs.each do |dir|
+    Dir.glob("#{root_dir}/#{dir}/**/*.rb").each { |f| load(f) }
+  end
+  # Return true when complete.
+  true
+end
+
 require 'pry'
 Pry.start

--- a/bin/console
+++ b/bin/console
@@ -14,7 +14,7 @@ def reload!(print = true)
   # Main project directory.
   root_dir = File.expand_path('..', __dir__)
   # Directories within the project that should be reloaded.
-  reload_dirs = %w{lib}
+  reload_dirs = %w[lib]
   # Loop through and reload every file in all relevant project directories.
   reload_dirs.each do |dir|
     Dir.glob("#{root_dir}/#{dir}/**/*.rb").each { |f| load(f) }

--- a/lib/fusuma/plugin/filters/libinput_timeout_filter.rb
+++ b/lib/fusuma/plugin/filters/libinput_timeout_filter.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative './filter.rb'
+require_relative '../../libinput_command.rb'
+
+module Fusuma
+  module Plugin
+    module Filters
+      # Filter device log
+      class LibinputTimeoutFilter < Filter
+        DEFAULT_SOURCE = 'libinput_command_input'
+
+        # @return [TrueClass] when keeping it
+        # @return [FalseClass] when discarding it
+        def keep?(record)
+          record.to_s == LibinputCommand::TIMEOUT_MESSAGE
+        end
+      end
+    end
+  end
+end

--- a/lib/fusuma/plugin/inputs/libinput_command_input.rb
+++ b/lib/fusuma/plugin/inputs/libinput_command_input.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../../libinput_command.rb'
 require_relative './input.rb'
 
 module Fusuma
@@ -18,7 +19,13 @@ module Fusuma
         end
 
         def run
-          LibinputCommand.new(libinput_options: libinput_options).debug_events do |line|
+          LibinputCommand.new(
+            libinput_options: libinput_options,
+            commands: {
+              debug_events_command: debug_events_command,
+              list_devices_command: list_devices_command
+            }
+          ).debug_events do |line|
             yield event(record: line)
           end
         end
@@ -36,6 +43,14 @@ module Fusuma
             show_keycodes,
             verbose
           ].compact
+        end
+
+        def debug_events_command
+          config_params(:'libinput-debug-events')
+        end
+
+        def list_devices_command
+          config_params(:'libinput-list-devices')
         end
       end
     end


### PR DESCRIPTION
Create a timeout event when libinput-debug-events doesn't output anything.
For detecting hold gestures correctly, require this feature.