### PR TITLE
Switch Psych arguments

### DIFF
--- a/lib/fusuma/config/yaml_duplication_checker.rb
+++ b/lib/fusuma/config/yaml_duplication_checker.rb
@@ -6,8 +6,14 @@ module Fusuma
     # Find duplicated keys from YAML.
     module YAMLDuplicationChecker
       def self.check(yaml_string, filename, &on_duplicated)
-        # Specify filename to display helpful message when it raises an error.
-        tree = YAML.parse(yaml_string, filename: filename)
+        # Ruby 2.6+
+        tree = if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0')
+                 # Specify filename to display helpful message when it raises
+                 # an error.
+                 YAML.parse(yaml_string, filename: filename)
+               else
+                 YAML.parse(yaml_string, filename)
+               end
         return unless tree
 
         traverse(tree, &on_duplicated)


### PR DESCRIPTION
* Psych v3.1.0 or older uses incompatible keyword arguments `filename:`
* Ruby v2.5.0(ubuntu 18.04) ships with old Psych less than v3.1.0
* Use keyword arguments of YAML.parse if Psych v3.1.0 or later

#194