### PR TITLE
fix for 'cannot load such file -- revdev' in arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ $ sudo pacman -S ruby
 To install gems system-wide, see any of the methods listed on [Arch Wiki](https://wiki.archlinux.org/index.php/ruby#Installing_gems_system-wide)
 
 ```zsh
+$ sudo gem install revdev
+$ sudo gem install bundler
 $ sudo gem install fusuma
 ```
 


### PR DESCRIPTION
This fixes the error '/usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require': cannot load such file -- revdev (LoadError)' in arch based distros
