### PR TITLE
test(custom_process): stub block_context in fork

### DIFF
--- a/spec/lib/custom_process_spec.rb
+++ b/spec/lib/custom_process_spec.rb
@@ -15,13 +15,14 @@ module Fusuma
 
     describe '.fork' do
       before do
-        allow(Process).to receive(:fork)
+        @test_instance = ForkTest.new
       end
       it 'call Process.fork and Process.setproctitle' do
-        expect(Process).to receive(:fork).and_yield do
-          expect(Process).to receive(:setproctitle)
+        expect(Process).to receive(:fork).and_yield do |block_context|
+          allow(block_context).to receive(:proctitle).and_return(@test_instance.proctitle)
+          expect(Process).to receive(:setproctitle).with(@test_instance.proctitle)
         end
-        ForkTest.new.call
+        @test_instance.call
       end
     end
   end


### PR DESCRIPTION
Fix the following error in Rspec
```
 NameError:
   undefined local variable or method `proctitle' for #<Object:0x0000556048b27b38>
 # ./lib/fusuma/custom_process.rb:12:in `block in fork'
 # ./lib/fusuma/custom_process.rb:11:in `fork'
 # ./spec/lib/custom_process_spec.rb:12:in `call'
```

Closes #272 
