### PR TITLE
fix(coverage): use Simplecov instead of Coverall

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gemspec
 
 gem 'bump'
 gem 'bundler'
-gem 'coveralls'
 gem 'github_changelog_generator', '~> 1.16'
 gem 'pry-byebug', '~> 3.4'
 gem 'pry-doc'
@@ -21,4 +20,5 @@ gem 'rspec-parameterized'
 gem 'rubocop'
 gem 'rubocop-rake'
 gem 'rubocop-rspec'
+gem 'simplecov'
 gem 'yard'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fusuma [![Gem Version](https://badge.fury.io/rb/fusuma.svg)](https://badge.fury.io/rb/fusuma) [![Build Status](https://github.com/iberianpig/fusuma/actions/workflows/ubuntu.yml/badge.svg)](https://github.com/iberianpig/fusuma/actions/workflows/ubuntu.yml) [![Coverage Status](https://coveralls.io/repos/github/iberianpig/fusuma/badge.svg?branch=master)](https://coveralls.io/github/iberianpig/fusuma?branch=master)
+# Fusuma [![Gem Version](https://badge.fury.io/rb/fusuma.svg)](https://badge.fury.io/rb/fusuma) [![Build Status](https://github.com/iberianpig/fusuma/actions/workflows/ubuntu.yml/badge.svg)](https://github.com/iberianpig/fusuma/actions/workflows/ubuntu.yml)
 
 Fusuma is multitouch gesture recognizer.
 This gem makes your linux able to recognize swipes or pinchs and assign commands to them.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,8 @@
 
 require 'bundler/setup'
 require 'helpers/config_helper'
-require 'coveralls'
-Coveralls.wear!
+
+require 'simplecov'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -18,3 +18,6 @@ RSpec.configure do |config|
 
   config.include(Fusuma::ConfigHelper)
 end
+
+SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
+SimpleCov.start


### PR DESCRIPTION
Remove Coverall that has errors in Github Actions.
Use Simplecov for check coverage instead of Coverall.

It shows coverage when running RSpec in the developer's local environment.

```sh
$ bundle exec rspec

....
Finished in 0.45914 seconds (files took 0.56276 seconds to load)
189 examples, 0 failures, 7 pending

Coverage report generated for RSpec to /home/iberianpig/.ghq/github.com/iberianpig/fusuma/coverage. 2162 / 2322 LOC (93.11%) covered.
```

Then, open the result of coverage on the browser
```sh
$ open ./coverage/index.html
```

[![Image from Gyazo](https://i.gyazo.com/dceb1f0441c4bfc2eae29d113465767d.gif)](https://gyazo.com/dceb1f0441c4bfc2eae29d113465767d)



closes: #270 
