### PR TITLE
use grep to filter out pointer events

### DIFF
--- a/lib/fusuma/libinput_command.rb
+++ b/lib/fusuma/libinput_command.rb
@@ -40,10 +40,9 @@ module Fusuma
     # @return [Integer] return a latest line libinput debug-events
     def debug_events(writer)
       @debug_events ||= begin
-        pid = Process.spawn(debug_events_with_options, out: writer,
-                                                       in: '/dev/null')
-        Process.detach(pid)
-        pid
+        t = Open3.pipeline_start([debug_events_with_options], ['grep -v POINTER_ --line-buffered'],
+                                 out: writer, in: '/dev/null')
+        t[0].pid
       end
     end
 

--- a/spec/lib/libinput_command_spec.rb
+++ b/spec/lib/libinput_command_spec.rb
@@ -132,8 +132,12 @@ module Fusuma
         end
 
         it 'should call dummy events' do
-          expect(Process).to receive(:spawn).with('dummy_debug_events',
-                                                  { out: @dummy_io, in: '/dev/null' }).once
+          th = double(Thread, pid: 'dummy pid')
+          expect(Open3).to receive(:pipeline_start).with(
+            ['dummy_debug_events'],
+            ['grep -v POINTER_ --line-buffered'],
+            { out: @dummy_io, in: '/dev/null' }
+          ).once.and_return([th])
           subject
         end
       end


### PR DESCRIPTION
On my computer moving the cursor with the touchpad or scrolling would generated quite high (~10%) cpu usage from fusuma. It seems like this is due to the large amount of output generated by `libinput debug-events`. Removing all of the `POINTER_MOTION` and `POINTER_SCROLL_FINGER` events with grep fixed that for me (I guess grep is much more cpu-efficient than ruby...).

I already wrote this code for use on my computer so I wasn't sure it was necessary to open an issue before creating this PR

- [ ] Follow the instructions in [CONTRIBUTING](https://github.com/iberianpig/fusuma/blob/master/CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rspec` and `bundle exec rubocop`.  
This doesn't introduce any rubocop complaints but rspec needs to be updated (I don't know ruby and don't really have an idea how to do it)

- [X] Update code documentation if necessary. Not necessary (I think)

