### PR TITLE
Fixing Installsection for Arch Part 2 - Electric Bogaloo :D

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ sudo apt-get install xdotool
 You need `libinput` release 1.0 or later. This is most probably installed by default on Manjaro
 
 ```sh
-sudo pacman -S libinput
+sudo pacman -Syu libinput
 ```
 
 #### 2. Install Ruby
@@ -89,7 +89,7 @@ sudo pacman -S libinput
 Fusuma runs in Ruby, so you must install it first.
 
 ```sh
-sudo pacman -S ruby
+sudo pacman -Syu ruby
 ```
 
 #### 3. Install Fusuma
@@ -107,7 +107,7 @@ sudo gem install fusuma
 For sending shortcuts:
 
 ```sh
-sudo pacman -S xdotool
+sudo pacman -Syu xdotool
 ```
 **For the truly lazy people:** As with pretty much anything else available as Open-Source-Software, you can install Fusuma via a package from the AUR. As off time of writing (March 2023), the package you would want is called `ruby-fusuma`.
 


### PR DESCRIPTION
Just a small Change in the pacman-commands:

Due to how fast Arch is progressing as a Rolling-Release AND Bleeding-Edge-Distribution, it is recommended to perform Packagelist-Updates and Package-Upgrades before installing new Software. "pacman -S nameofpackage" might try to install an outdated version of a package plus maybe outdated dependencies, potentially leading to mismatching Versions of dependencies shared with other explicitly installed packages or might - even worse - induce a state of only partially being up to date, which can make the hostsystem highly unstable/fragile. Instead one is supposed to run "pacman -Syu nameofpackage". This pulls the latest Softwarecatalogue from available Mirrors as well as then grabbing all the new updates available before installing the new package, preventing Versionmismatching - while even the ArchWiki occasionally uses pacman -S as code, afaik only -Syu is the recommended way of grabbing new software, ESPECIALLY if you havent updated your system until a few minutes before installing the new software.