### PR TITLE
Optimize gesture buffer

### DIFF
--- a/lib/fusuma/plugin/buffers/gesture_buffer.rb
+++ b/lib/fusuma/plugin/buffers/gesture_buffer.rb
@@ -72,7 +72,26 @@ module Fusuma
         def sum_attrs(attr)
           updating_events.map do |gesture_event|
             gesture_event.record.delta[attr].to_f
-          end.inject(:+)
+          end.reduce(:+)
+        end
+
+        # @param attr [Symbol]
+        # @return [Float]
+        def sum_last10_attrs(attr) # sums last 10 values of attr (or all if length < 10)
+          cache_entry = ( @cache[[:sum10, attr]] ||= CacheEntry.new(0, 0) )
+          upd_ev = updating_events
+          cache_entry.value = if upd_ev.length > cache_entry.checked + 1 then
+            upd_ev.last(10).map do |gesture_event|
+              gesture_event.record.delta[attr].to_f
+            end.reduce(:+)
+          elsif upd_ev.length > cache_entry.checked
+            cache_entry.value + upd_ev[-1].record.delta[attr].to_f - \
+            (upd_ev.length > 10 ? upd_ev[-11].record.delta[attr].to_f : 0)
+          else
+            return cache_entry.value
+          end
+          cache_entry.checked = upd_ev.length
+          cache_entry.value
         end
 
         def updating_events

--- a/lib/fusuma/plugin/buffers/gesture_buffer.rb
+++ b/lib/fusuma/plugin/buffers/gesture_buffer.rb
@@ -15,11 +15,15 @@ module Fusuma
         def initialize(*args)
           super(*args)
           @cache = {}
+          @cache_select_by = {}
+          @cache_sum10 = {}
         end
 
         def clear
           super.clear
           @cache = {}
+          @cache_select_by = {}
+          @cache_sum10 = {}
         end
 
         def config_param_types
@@ -53,6 +57,8 @@ module Fusuma
 
             @events.delete(e)
             @cache = {}
+            @cache_select_by = {}
+            @cache_sum10 = {}
           end
         end
 
@@ -78,7 +84,7 @@ module Fusuma
         # @param attr [Symbol]
         # @return [Float]
         def sum_last10_attrs(attr) # sums last 10 values of attr (or all if length < 10)
-          cache_entry = ( @cache[[:sum10, attr]] ||= CacheEntry.new(0, 0) )
+          cache_entry = ( @cache_sum10[attr] ||= CacheEntry.new(0, 0) )
           upd_ev = updating_events
           if upd_ev.length > cache_entry.checked + 1 then
             cache_entry.value = upd_ev.last(10).map do |gesture_event|
@@ -134,7 +140,7 @@ module Fusuma
         end
 
         def select_by_type(type)
-          cache_entry = ( @cache[[:select_by, type]] ||= CacheEntry.new(0, self.class.new([])) )
+          cache_entry = ( @cache_select_by[type] ||= CacheEntry.new(0, self.class.new([])) )
           cache_entry.checked.upto(@events.length - 1).each do |i|
             (cache_entry.value.events << @events[i]) if @events[i].record.gesture == type
           end

--- a/lib/fusuma/plugin/buffers/gesture_buffer.rb
+++ b/lib/fusuma/plugin/buffers/gesture_buffer.rb
@@ -80,13 +80,13 @@ module Fusuma
         def sum_last10_attrs(attr) # sums last 10 values of attr (or all if length < 10)
           cache_entry = ( @cache[[:sum10, attr]] ||= CacheEntry.new(0, 0) )
           upd_ev = updating_events
-          cache_entry.value = if upd_ev.length > cache_entry.checked + 1 then
-            upd_ev.last(10).map do |gesture_event|
+          if upd_ev.length > cache_entry.checked + 1 then
+            cache_entry.value = upd_ev.last(10).map do |gesture_event|
               gesture_event.record.delta[attr].to_f
             end.reduce(:+)
           elsif upd_ev.length > cache_entry.checked
-            cache_entry.value + upd_ev[-1].record.delta[attr].to_f - \
-            (upd_ev.length > 10 ? upd_ev[-11].record.delta[attr].to_f : 0)
+            cache_entry.value = cache_entry.value + upd_ev[-1].record.delta[attr].to_f - \
+              (upd_ev.length > 10 ? upd_ev[-11].record.delta[attr].to_f : 0)
           else
             return cache_entry.value
           end

--- a/lib/fusuma/plugin/detectors/hold_detector.rb
+++ b/lib/fusuma/plugin/detectors/hold_detector.rb
@@ -97,7 +97,7 @@ module Fusuma
         def find_hold_buffer(buffers)
           buffers.find { |b| b.type == BUFFER_TYPE }
             .select_from_last_begin
-            .select_by_events { |e| e.record.gesture == GESTURE_RECORD_TYPE }
+            .select_by_type(GESTURE_RECORD_TYPE)
         end
 
         def calc_holding_time(hold_events:, timer_events:)

--- a/lib/fusuma/plugin/detectors/pinch_detector.rb
+++ b/lib/fusuma/plugin/detectors/pinch_detector.rb
@@ -19,7 +19,7 @@ module Fusuma
         def detect(buffers)
           gesture_buffer = buffers.find { |b| b.type == BUFFER_TYPE }
             .select_from_last_begin
-            .select_by_events { |e| e.record.gesture == GESTURE_RECORD_TYPE }
+            .select_by_type(GESTURE_RECORD_TYPE)
 
           updating_events = gesture_buffer.updating_events
           return if updating_events.empty?

--- a/lib/fusuma/plugin/detectors/rotate_detector.rb
+++ b/lib/fusuma/plugin/detectors/rotate_detector.rb
@@ -24,16 +24,9 @@ module Fusuma
           updating_events = gesture_buffer.updating_events
           return if updating_events.empty?
 
-          oneshot_angle = if updating_events.size >= 10
-            updating_time = 100 * (updating_events[-1].time - updating_events[-10].time)
-            last_10 = gesture_buffer.class.new(updating_events[-10..-1])
-            last_10.sum_attrs(:rotate) / updating_time
-          else
-            updating_time = 100 * (updating_events.last.time - updating_events.first.time)
-            gesture_buffer.sum_attrs(:rotate) / updating_time
-          end
-
-          return if updating_events.empty?
+          updating_time = 100 * (updating_events[-1].time -
+                                 (updating_events[-10] || updating_events.first).time)
+          oneshot_angle = gesture_buffer.sum_last10_attrs(:rotate) / updating_time
 
           finger = gesture_buffer.finger
 

--- a/lib/fusuma/plugin/detectors/rotate_detector.rb
+++ b/lib/fusuma/plugin/detectors/rotate_detector.rb
@@ -19,7 +19,7 @@ module Fusuma
         def detect(buffers)
           gesture_buffer = buffers.find { |b| b.type == BUFFER_TYPE }
             .select_from_last_begin
-            .select_by_events { |e| e.record.gesture == GESTURE_RECORD_TYPE }
+            .select_by_type(GESTURE_RECORD_TYPE)
 
           updating_events = gesture_buffer.updating_events
           return if updating_events.empty?

--- a/lib/fusuma/plugin/detectors/swipe_detector.rb
+++ b/lib/fusuma/plugin/detectors/swipe_detector.rb
@@ -24,16 +24,10 @@ module Fusuma
           updating_events = gesture_buffer.updating_events
           return if updating_events.empty?
 
-          oneshot_move_x, oneshot_move_y = if updating_events.size >= 10
-            updating_time = 100 * (updating_events[-1].time - updating_events[-10].time)
-            last_10 = gesture_buffer.class.new(updating_events[-10..-1])
-            [last_10.sum_attrs(:move_x) / updating_time,
-              last_10.sum_attrs(:move_y) / updating_time]
-          else
-            updating_time = 100 * (updating_events.last.time - updating_events.first.time)
-            [gesture_buffer.sum_attrs(:move_x) / updating_time,
-              gesture_buffer.sum_attrs(:move_y) / updating_time]
-          end
+          updating_time = 100 * (updating_events.last.time -
+                                 (updating_events[-10] || updating_events.first).time)
+          oneshot_move_x = gesture_buffer.sum_last10_attrs(:move_x) / updating_time
+          oneshot_move_y = gesture_buffer.sum_last10_attrs(:move_y) / updating_time
 
           finger = gesture_buffer.finger
           status = case gesture_buffer.events.last.record.status

--- a/lib/fusuma/plugin/detectors/swipe_detector.rb
+++ b/lib/fusuma/plugin/detectors/swipe_detector.rb
@@ -34,7 +34,6 @@ module Fusuma
             [gesture_buffer.sum_attrs(:move_x) / updating_time,
               gesture_buffer.sum_attrs(:move_y) / updating_time]
           end
-          (gesture_buffer.sum_attrs(:move_x) / updating_time)
 
           finger = gesture_buffer.finger
           status = case gesture_buffer.events.last.record.status

--- a/lib/fusuma/plugin/detectors/swipe_detector.rb
+++ b/lib/fusuma/plugin/detectors/swipe_detector.rb
@@ -19,7 +19,7 @@ module Fusuma
         def detect(buffers)
           gesture_buffer = buffers.find { |b| b.type == BUFFER_TYPE }
             .select_from_last_begin
-            .select_by_events { |e| e.record.gesture == GESTURE_RECORD_TYPE }
+            .select_by_type(GESTURE_RECORD_TYPE)
 
           updating_events = gesture_buffer.updating_events
           return if updating_events.empty?


### PR DESCRIPTION
This PR has the changes I explained in https://github.com/iberianpig/fusuma/pull/296 (that's the first commit). Following the same pattern I added more caches to avoid looking at the whole buffer over and over again.
The ruby 2.5 incompatibility that you mentioned in the review should be fixed.

Benchmark: I ran `20000.times { pipeline }` with both versions, feeding them touchpad events that I had recorded for a couple of hours. The results show a 20% speedup

| version | time |
|----------|--------------------|
| b68ab603 | 5.987 s ±  0.112 s |
| this PR  | 4.927 s ±  0.022 s |