### PR TITLE
Optimize by avoiding pattern matching

### DIFF
--- a/lib/fusuma/device.rb
+++ b/lib/fusuma/device.rb
@@ -66,6 +66,7 @@ module Fusuma
         line_parser = LineParser.new
 
         libinput_command = Plugin::Inputs::LibinputCommandInput.new.command
+        # note: this libinput command takes a nontrivial amout of time (~200ms)
         libinput_command.list_devices do |line|
           line_parser.push(line)
         end

--- a/lib/fusuma/plugin/detectors/detector.rb
+++ b/lib/fusuma/plugin/detectors/detector.rb
@@ -8,6 +8,15 @@ module Fusuma
     module Detectors
       # Inherite this base
       class Detector < Base
+        def initialize(*args)
+          super(*args)
+          @tag = self.class.tag
+          @type = self.class.type
+        end
+
+        attr_reader :tag
+        attr_reader :type
+
         # @return [Array<String>]
         def sources
           @sources ||= self.class.const_get(:SOURCES)
@@ -41,14 +50,6 @@ module Fusuma
 
         def first_time?
           @last_time.nil?
-        end
-
-        def tag
-          self.class.tag
-        end
-
-        def type
-          self.class.type
         end
 
         class << self

--- a/lib/fusuma/plugin/filters/libinput_device_filter.rb
+++ b/lib/fusuma/plugin/filters/libinput_device_filter.rb
@@ -26,7 +26,7 @@ module Fusuma
             return false
           end
           device_id = record.to_s.match(/\S*/, 1).to_s
-          keep_device.all_ids.include?(device_id)
+          keep_device.all.map(&:id).include?(device_id)
         end
 
         def keep_device
@@ -58,13 +58,13 @@ module Fusuma
 
           # remove cache for reloading new devices
           def reset
-            @all_ids = nil
+            @all = nil
             Device.reset
           end
 
           # @return [Array]
-          def all_ids
-            @all_ids ||= if @name_patterns.empty?
+          def all
+            @all ||= if @name_patterns.empty?
               Device.available
             else
               Device.all.select do |device|
@@ -72,7 +72,7 @@ module Fusuma
               end
             end.tap do |devices|
               print_not_found_messages if devices.empty?
-            end.map(&:id)
+            end
           end
 
           def print_not_found_messages

--- a/lib/fusuma/plugin/filters/libinput_device_filter.rb
+++ b/lib/fusuma/plugin/filters/libinput_device_filter.rb
@@ -25,7 +25,8 @@ module Fusuma
             keep_device.reset
             return false
           end
-          keep_device.all.map(&:id).any? { |device_id| record.to_s =~ /^[\s-]?#{device_id}\s/ }
+          device_id = record.to_s.match(/\S*/, 1).to_s
+          keep_device.all_ids.include?(device_id)
         end
 
         def keep_device
@@ -57,13 +58,13 @@ module Fusuma
 
           # remove cache for reloading new devices
           def reset
-            @all = nil
+            @all_ids = nil
             Device.reset
           end
 
           # @return [Array]
-          def all
-            @all ||= if @name_patterns.empty?
+          def all_ids
+            @all_ids ||= if @name_patterns.empty?
               Device.available
             else
               Device.all.select do |device|
@@ -71,7 +72,7 @@ module Fusuma
               end
             end.tap do |devices|
               print_not_found_messages if devices.empty?
-            end
+            end.map(&:id)
           end
 
           def print_not_found_messages

--- a/lib/fusuma/plugin/inputs/input.rb
+++ b/lib/fusuma/plugin/inputs/input.rb
@@ -9,6 +9,13 @@ module Fusuma
       # Inherite this base
       # @abstract Subclass and override {#io} to implement
       class Input < Base
+        def initialize(*args)
+          super(*args)
+          @tag = self.class.name.split("Inputs::").last.underscore
+        end
+
+        attr_reader :tag
+
         # Wait multiple inputs until it becomes readable
         # @param inputs [Array<Input>]
         # @return [Event]
@@ -52,10 +59,6 @@ module Fusuma
           e = Events::Event.new(tag: tag, record: record)
           MultiLogger.debug(input_event: e)
           e
-        end
-
-        def tag
-          self.class.name.split("Inputs::").last.underscore
         end
       end
     end


### PR DESCRIPTION
Apparently ruby's string matching is quite slow. This makes the `String.underscore` function slow, so the first commit avoids calling it in the hot code path. The second commit speeds up the pattern-matching when filtering by device (this is instead of the `@keep_all` approach I suggested before).

Benchmark: I ran `20000.times { pipeline }` with both versions, feeding them touchpad events that I had recorded for a couple of hours. The results show a 18% speedup

| version | time |
|----------|--------------------|
| b68ab603 | 5.024 s ±  0.058 s |
| this PR  | 4.256 s ±  0.035 s |