### PR TITLE
Set default values for config_params

### DIFF
--- a/exe/fusuma
+++ b/exe/fusuma
@@ -27,6 +27,10 @@ opt.on('--log=path/to/file',
   option[:log_filepath] = v
 end
 
+opt.on('--show-config', 'Show config as YAML format which is loaded internally') do |v|
+  option[:show_config] = v
+end
+
 opt.on('--device="Device name"',
        'Open the given device only (DEPRECATED)') do |v|
   option[:device] = v

--- a/lib/fusuma.rb
+++ b/lib/fusuma.rb
@@ -27,9 +27,9 @@ module Fusuma
         MultiLogger.filepath = option[:log_filepath]
         MultiLogger.instance.debug_mode = option[:verbose]
 
-        load_custom_config(option[:config_path])
-
         Plugin::Manager.require_base_plugins
+
+        load_custom_config(option[:config_path])
 
         Environment.dump_information
         Kernel.exit(0) if option[:version]

--- a/lib/fusuma.rb
+++ b/lib/fusuma.rb
@@ -34,6 +34,11 @@ module Fusuma
         Environment.dump_information
         Kernel.exit(0) if option[:version]
 
+        if option[:show_config]
+          Environment.print_config
+          Kernel.exit(0)
+        end
+
         if option[:list]
           Environment.print_device_list
           Kernel.exit(0)

--- a/lib/fusuma/config/searcher.rb
+++ b/lib/fusuma/config/searcher.rb
@@ -111,7 +111,6 @@ module Fusuma
         end
 
         attr_reader :context
-
       end
     end
   end

--- a/lib/fusuma/environment.rb
+++ b/lib/fusuma/environment.rb
@@ -39,6 +39,12 @@ module Fusuma
           puts device.name
         end
       end
+
+      def print_config
+        Config.instance.keymap.each do |conf|
+          puts conf.deep_stringify_keys.to_yaml
+        end
+      end
     end
   end
 end

--- a/lib/fusuma/hash_support.rb
+++ b/lib/fusuma/hash_support.rb
@@ -2,6 +2,10 @@
 
 # Patch to hash
 class Hash
+  def deep_stringify_keys
+    deep_transform_keys(&:to_s)
+  end
+
   # activesupport-4.1.1/lib/active_support/core_ext/hash/keys.rb
   def deep_symbolize_keys
     deep_transform_keys do |key|

--- a/lib/fusuma/hash_support.rb
+++ b/lib/fusuma/hash_support.rb
@@ -2,6 +2,24 @@
 
 # Patch to hash
 class Hash
+  # activesupport-5.2.0/lib/active_support/core_ext/hash/deep_merge.rb
+  def deep_merge(other_hash, &block)
+    dup.deep_merge!(other_hash, &block)
+  end
+
+  # Same as +deep_merge+, but modifies +self+.
+  def deep_merge!(other_hash, &block)
+    merge!(other_hash) do |key, this_val, other_val|
+      if this_val.is_a?(Hash) && other_val.is_a?(Hash)
+        this_val.deep_merge(other_val, &block)
+      elsif block_given?
+        block.call(key, this_val, other_val)
+      else
+        other_val
+      end
+    end
+  end
+
   def deep_stringify_keys
     deep_transform_keys(&:to_s)
   end

--- a/lib/fusuma/hash_support.rb
+++ b/lib/fusuma/hash_support.rb
@@ -12,7 +12,7 @@ class Hash
     merge!(other_hash) do |key, this_val, other_val|
       if this_val.is_a?(Hash) && other_val.is_a?(Hash)
         this_val.deep_merge(other_val, &block)
-      elsif block_given?
+      elsif block
         block.call(key, this_val, other_val)
       else
         other_val

--- a/lib/fusuma/plugin/base.rb
+++ b/lib/fusuma/plugin/base.rb
@@ -31,14 +31,20 @@ module Fusuma
         raise NotImplementedError, "override #{self.class.name}##{__method__}"
       end
 
+      # @param key [Symbol]
+      # @param base [Config::Index]
       # @return [Object]
-      def config_params(key = nil, base: config_index)
-        params = Config.search(base) || {}
+      def config_params(key = nil)
+        @config_params ||= {}
+        if @config_params["#{config_index.cache_key},#{key}"]
+          return @config_params["#{config_index.cache_key},#{key}"]
+        end
+
+        params = Config.instance.fetch_config_params(key, config_index)
 
         return params unless key
 
-        @config_params ||= {}
-        @config_params["#{base.cache_key},#{key}"] ||=
+        @config_params["#{config_index.cache_key},#{key}"] =
           params.fetch(key, nil).tap do |val|
             next if val.nil?
 
@@ -55,7 +61,7 @@ module Fusuma
       end
 
       def config_index
-        Config::Index.new(self.class.name.gsub("Fusuma::", "").underscore.split("/"))
+        @config_index ||= Config::Index.new(self.class.name.gsub("Fusuma::", "").underscore.split("/"))
       end
     end
   end

--- a/lib/fusuma/plugin/inputs/libinput_command_input.yml
+++ b/lib/fusuma/plugin/inputs/libinput_command_input.yml
@@ -1,0 +1,3 @@
+plugin:
+  inputs:
+    libinput_command_input:

--- a/lib/fusuma/plugin/manager.rb
+++ b/lib/fusuma/plugin/manager.rb
@@ -115,6 +115,12 @@ module Fusuma
           @plugins ||= {}
         end
 
+        # @return [Array<String>]
+        # @example
+        #   Manager.load_paths
+        #   => ["/path/to/fusuma/lib/fusuma/plugin/inputs/input.rb",
+        #       "/path/to/fusuma/lib/fusuma/plugin/inputs/libinput_command_input.rb",
+        #       "/path/to/fusuma/lib/fusuma/plugin/inputs/timer_input.rb"]
         def load_paths
           @load_paths ||= []
         end

--- a/spec/fusuma/config/searcher_spec.rb
+++ b/spec/fusuma/config/searcher_spec.rb
@@ -57,7 +57,7 @@ module Fusuma
             ]
           end
           it "detects ctrl+minus with skip" do
-            value =  Config::Searcher.new.search(index, location: location)
+            value = Config::Searcher.new.search(index, location: location)
             expect(value).to eq("ctrl+minus")
           end
         end

--- a/spec/fusuma/plugin/buffers/buffer_spec.rb
+++ b/spec/fusuma/plugin/buffers/buffer_spec.rb
@@ -71,8 +71,8 @@ module Fusuma
             Config.custom_path = nil
           end
 
-          subject { @buffer.config_params }
-          it { is_expected.to eq(dummy: "dummy") }
+          subject { @buffer.config_params(:dummy) }
+          it { is_expected.to eq("dummy") }
         end
       end
     end

--- a/spec/fusuma/plugin/buffers/gesture_buffer_spec.rb
+++ b/spec/fusuma/plugin/buffers/gesture_buffer_spec.rb
@@ -102,7 +102,7 @@ module Fusuma
             end
 
             it "should keep only events generated within 0.3 seconds" do
-              expect(@buffer.config_params).to eq(seconds_to_keep: 0.3)
+              expect(@buffer.config_params(:seconds_to_keep)).to eq(0.3)
               time = Time.now
               event1 = @event_generator.call(time)
               @buffer.buffer(event1)

--- a/spec/fusuma/plugin/detectors/detector_spec.rb
+++ b/spec/fusuma/plugin/detectors/detector_spec.rb
@@ -35,7 +35,7 @@ module Fusuma
         end
 
         describe "#config_params" do
-          it { expect(@detector.config_params).to eq(dummy: "dummy") }
+          it { expect(@detector.config_params(:dummy)).to eq("dummy") }
         end
       end
     end

--- a/spec/fusuma/plugin/detectors/dummy_detector.rb
+++ b/spec/fusuma/plugin/detectors/dummy_detector.rb
@@ -18,6 +18,12 @@ module Fusuma
             return create_event(record: record)
           end
         end
+
+        def config_param_types
+          {
+            dummy: String
+          }
+        end
       end
     end
   end

--- a/spec/fusuma/plugin/executors/executor_spec.rb
+++ b/spec/fusuma/plugin/executors/executor_spec.rb
@@ -27,6 +27,12 @@ module Fusuma
       end
 
       class DummyExecutor < Executor
+        def config_param_types
+          {
+            dummy: String
+          }
+        end
+
         def execute_keys
           [:dummy]
         end
@@ -171,7 +177,7 @@ module Fusuma
         end
 
         describe "#config_params" do
-          it { expect(@executor.config_params).to eq(dummy: "dummy") }
+          it { expect(@executor.config_params(:dummy)).to eq("dummy") }
         end
       end
     end

--- a/spec/fusuma/plugin/filters/filter_spec.rb
+++ b/spec/fusuma/plugin/filters/filter_spec.rb
@@ -15,7 +15,8 @@ module Fusuma
 
         def config_param_types
           {
-            source: String
+            source: String,
+            dummy: String,
           }
         end
       end
@@ -83,8 +84,8 @@ module Fusuma
             Config.custom_path = nil
           end
 
-          subject { filter.config_params }
-          it { is_expected.to eq(dummy: "dummy") }
+          subject { filter.config_params(:dummy) }
+          it { is_expected.to eq("dummy") }
         end
       end
     end

--- a/spec/fusuma/plugin/inputs/input_spec.rb
+++ b/spec/fusuma/plugin/inputs/input_spec.rb
@@ -29,6 +29,12 @@ module Fusuma
       end
 
       class DummyInput < Input
+        def config_param_types
+          {
+            dummy: String
+          }
+        end
+
         def io
           @io ||= begin
             r, w = IO.pipe
@@ -61,8 +67,8 @@ module Fusuma
         end
 
         describe "#config_params" do
-          subject { dummy_input.config_params }
-          it { is_expected.to eq(dummy: "dummy") }
+          subject { dummy_input.config_params(:dummy) }
+          it { is_expected.to eq("dummy") }
         end
       end
     end


### PR DESCRIPTION
## Motivation

Sometimes you want to set the default value of config_params for each plugin.
This is because you want to set the configuration values of other plugins from different plugins.

For example, the configuration values in my LibinputCommandInput are as follows,
but I believe the following options should be set automatically without setting anything by user.


```yaml
plugin:
  inputs:
    libinput_command_input:
      show-keycodes: true # fusuma-plugin-keypress requires this option
      verbose: true       # fusuma-plugin-thumbsense requires this option
```

fusuma-plugin-keypress and fusuma-plugin-thumbsense require these options.

## Solution

These should be set automatically by plugins, and should only be written if the user wants to change them.

Make it possible to include yml files for each plugin.
This PR includes a yml file for libinput_command_input.
Also, add the --show-config option to dump and check the config values.

<details><summary>example: fusuma --show-config</summary>
<p>

```yaml
---
plugin:
  inputs:
    remap_keyboard_input:
      keyboard_name_patterns: xremap
hold:
  '4':
    sendkey: LEFTCTRL+SPACE
    threshold: 0.5
swipe:
  '3':
    right:
      update:
        keypress:
          LEFTALT:
            interval: 1
            sendkey: VOLUMEUP
            clearmodifiers: true
    left:
      update:
        keypress:
          LEFTALT:
            interval: 1
            sendkey: VOLUMEDOWN
    up:
      update:
        keypress:
          LEFTALT:
            interval: 1
            command: gdbus call --session --dest org.gnome.SettingsDaemon.Power --object-path
              /org/gnome/SettingsDaemon/Power --method org.gnome.SettingsDaemon.Power.Screen.StepUp
    down:
      update:
        keypress:
          LEFTALT:
            interval: 1
            command: gdbus call --session --dest org.gnome.SettingsDaemon.Power --object-path
              /org/gnome/SettingsDaemon/Power --method org.gnome.SettingsDaemon.Power.Screen.StepDown
  '4':
    up:
      sendkey: LEFTMETA+S
      keypress:
        LEFTSHIFT:
          sendkey: LEFTMETA+DOWN
          clearmodifiers: true
        LEFTMETA:
          sendkey: LEFTMETA+LEFTSHIFT+UP
          clearmodifiers: true
    down:
      sendkey: LEFTMETA+W
      keypress:
        LEFTSHIFT:
          sendkey: LEFTMETA+UP
          clearmodifiers: true
        LEFTMETA:
          sendkey: LEFTMETA+LEFTSHIFT+DOWN
          clearmodifiers: true
    left:
      sendkey: LEFTMETA+D
      keypress:
        LEFTSHIFT:
          sendkey: LEFTMETA+RIGHT
          clearmodifiers: true
    right:
      sendkey: LEFTMETA+A
      keypress:
        LEFTSHIFT:
          sendkey: LEFTMETA+LEFT
          clearmodifiers: true
pinch:
  '2':
    begin:
      command: xdotool keydown ctrl
    end:
      command: xdotool keyup ctrl
    in:
      update:
        command: xdotool click 5
        keypress:
          LEFTALT:
            sendkey: VOLUMEUP
    out:
      update:
        command: xdotool click 4
        keypress:
          LEFTALT:
            sendkey: VOLUMEDOWN
rotate:
  '3':
    clockwise:
      update:
        sendkey: VOLUMEUP
        keypress:
          LEFTALT:
            command: gdbus call --session --dest org.gnome.SettingsDaemon.Power --object-path
              /org/gnome/SettingsDaemon/Power --method org.gnome.SettingsDaemon.Power.Screen.StepUp
    counterclockwise:
      update:
        sendkey: VOLUMEDOWN
        keypress:
          LEFTALT:
            command: gdbus call --session --dest org.gnome.SettingsDaemon.Power --object-path
              /org/gnome/SettingsDaemon/Power --method org.gnome.SettingsDaemon.Power.Screen.StepDown
---
context:
  application: Google-chrome
swipe:
  '3':
    left:
      sendkey: LEFTALT+RIGHT
    right:
      sendkey: LEFTALT+LEFT
    up:
      sendkey: LEFTCTRL+T
    down:
      sendkey: LEFTCTRL+W
---
context:
  application: Microsoft-edge-dev
swipe:
  '3':
    left:
      sendkey: LEFTALT+RIGHT
    right:
      sendkey: LEFTALT+LEFT
    up:
      sendkey: LEFTCTRL+T
    down:
      sendkey: LEFTCTRL+W
---
context:
  application: Slack
swipe:
  '3':
    up:
      sendkey: LEFTALT+DOWN
    down:
      sendkey: LEFTALT+UP
---
context:
  application: Alacritty
swipe:
  '3':
    begin:
      keypress:
        LEFTCTRL:
          command: xdotool mousedown 1
          interval: 0.0
    update:
      keypress:
        LEFTCTRL:
          command: xdotool mousemove_relative -- $move_x, $move_y
          interval: 0.0
          accel: 3
    end:
      keypress:
        LEFTCTRL:
          interval: 0.0
          command: xdotool mouseup 1
remap:
  LEFTMETA: A
---
context:
  thumbsense: true
remap:
  J: BTN_LEFT
  K: BTN_RIGHT
  F: BTN_LEFT
  D: BTN_RIGHT
  SPACE: BTN_LEFT
  I: INSERT
  LEFTALT:
    sendkey: ALT+LEFT
---
context: :plugin_defaults
plugin:
  inputs:
    libinput_command_input:
      show-keycodes: true
      verbose: true
  buffers:
    keypress_buffer:
      source: remap_keyboard_input
  filters:
    keypress_filter:
      keep_device_names:
  executors:
    wmctrl_executor:
      wrap-navigation: false
      matrix-col-size:

```


</p>
</details> 

