### PR TITLE
fix: call block with plugin_default_context

### DIFF
--- a/lib/fusuma/config/searcher.rb
+++ b/lib/fusuma/config/searcher.rb
@@ -165,7 +165,10 @@ module Fusuma
 
             return config[:context] if with_context(config[:context], &block)
           end
-          complete_match_context
+          if complete_match_context
+            with_context(complete_match_context, &block)
+            complete_match_context
+          end
         end
       end
     end


### PR DESCRIPTION

I introduced plugin_defaults as an internal function for setting default values for fusuma plugins, but the search logic contained a bug.
fusuma-plugin-sendkey uses plugin_defaults to set the default value of device_names.  ref: https://github.com/iberianpig/fusuma-plugin-sendkey/issues/33

```yaml
---
plugin:
executors:
 sendkey_executor:
   device_name: keyboard|Keyboard|KEYBOARD
```
Before the fix, the block was not evaluated when the context was a complete match, so the plugin could not get the default value.
