### PR TITLE
fix: cutting out read_from_io from Input class

### DIFF
--- a/spec/fusuma/plugin/inputs/input_spec.rb
+++ b/spec/fusuma/plugin/inputs/input_spec.rb
@@ -66,6 +66,11 @@ module Fusuma
           it { is_expected.to be_a IO }
         end
 
+        describe "#read_from_io" do
+          subject { dummy_input.read_from_io }
+          it { is_expected.to eq "hoge" }
+        end
+
         describe "#config_params" do
           subject { dummy_input.config_params(:dummy) }
           it { is_expected.to eq("dummy") }


### PR DESCRIPTION
- To change the way to extract data after IO.select, override Input#read_from_io method
- When using binary encoded packed data containing "\n" in the data with input plugin using msgpack, an error occurred
- With the previous implementation, the input plugin depended on `io.readline(chomp: true)` when extracting data after IO.select, so the input plugin needed to send a string containing a newline
- By cutting out read_from_io method, each plugin can extend the way data is extracted
