### PR TITLE
Enable Comparison of Index Records in Fusuma

### DIFF
--- a/lib/fusuma/config/index.rb
+++ b/lib/fusuma/config/index.rb
@@ -14,7 +14,7 @@ module Fusuma
             key = Key.new(key) if !key.is_a? Key
             @keys << key
             key.symbol
-          end.join(",")
+          end.join(",").to_sym
         else
           key = Key.new(keys)
           @cache_key = key.symbol
@@ -24,6 +24,12 @@ module Fusuma
 
       def to_s
         @keys.map(&:inspect)
+      end
+
+      def ==(other)
+        return false unless other.is_a? Index
+
+        cache_key == other.cache_key
       end
 
       attr_reader :keys, :cache_key

--- a/lib/fusuma/config/index.rb
+++ b/lib/fusuma/config/index.rb
@@ -22,7 +22,7 @@ module Fusuma
         end
       end
 
-      def inspect
+      def to_s
         @keys.map(&:inspect)
       end
 
@@ -40,7 +40,7 @@ module Fusuma
           @skippable = skippable
         end
 
-        def inspect
+        def to_s
           if @skippable
             "#{@symbol}(skippable)"
           else


### PR DESCRIPTION
In Fusuma, frequent comparisons are made to check if the gesture index matches the configured one. This also occurs in test cases. For performance considerations, it seems more effective to compare using cache_key and :symbol.
