### PR TITLE
fix: restore context after block.call

### DIFF
--- a/lib/fusuma/config/searcher.rb
+++ b/lib/fusuma/config/searcher.rb
@@ -84,6 +84,7 @@ module Fusuma
         def with_context(context, &block)
           @context = context || {}
           result = block.call
+        ensure # NOTE: ensure is called even if return in block
           @context = {}
           result
         end


### PR DESCRIPTION
closes: #317

ref: https://github.com/iberianpig/fusuma-plugin-wmctrl/pull/14#issuecomment-1912350289


If return is called in the with_context block, the context cannot be restored to its original state.
The "ensure" clause call post-processing even if it called returned in the middle of block.call.

The following problems were occurring: 
1. First, config_params.fetch is called, :plugin_default_context is used as Context for the search 
1. Then when Executor#executable? is called, the search is executed with :plugin_default_context
1. Because Executor#executable? returns false, wmctrl is not executed.

