### PR TITLE
feat: support multiple context conditions (AND/OR)

### DIFF
--- a/lib/fusuma/config.rb
+++ b/lib/fusuma/config.rb
@@ -3,6 +3,7 @@
 require_relative "multi_logger"
 require_relative "config/index"
 require_relative "config/searcher"
+require_relative "config/context_matcher"
 require_relative "config/yaml_duplication_checker"
 require_relative "plugin/manager"
 require_relative "hash_support"

--- a/lib/fusuma/config/context_matcher.rb
+++ b/lib/fusuma/config/context_matcher.rb
@@ -29,7 +29,11 @@ module Fusuma
         def match_value?(expected, actual)
           case expected
           when Array
-            expected.include?(actual)
+            if actual.is_a?(Array)
+              expected == actual # exact match when both are arrays
+            else
+              expected.include?(actual) # OR condition
+            end
           else
             expected == actual
           end

--- a/lib/fusuma/config/context_matcher.rb
+++ b/lib/fusuma/config/context_matcher.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Fusuma
+  class Config
+    # Matches context conditions for configuration lookup.
+    # Supports AND (multiple keys) and OR (array values) conditions.
+    class ContextMatcher
+      class << self
+        # Check if config context matches request context.
+        # @param config_context [Hash, nil] context defined in YAML config
+        # @param request_context [Hash, nil] context from runtime
+        # @return [Boolean] true if matched
+        #: (Hash[untyped, untyped]?, Hash[untyped, untyped]?) -> bool
+        def match?(config_context, request_context)
+          return true if config_context.nil? || config_context.empty?
+          return false if request_context.nil? || request_context.empty?
+
+          config_context.all? do |key, expected_value|
+            match_value?(expected_value, request_context[key])
+          end
+        end
+
+        private
+
+        # @param expected [Object] expected value (single or array for OR)
+        # @param actual [Object] actual value from request context
+        # @return [Boolean] true if matched
+        #: (untyped, untyped) -> bool
+        def match_value?(expected, actual)
+          case expected
+          when Array
+            expected.include?(actual)
+          else
+            expected == actual
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fusuma/config/index.rb
+++ b/lib/fusuma/config/index.rb
@@ -45,6 +45,8 @@ module Fusuma
           @symbol = case symbol_word
           when Integer, Symbol
             symbol_word
+          when /\A[1-9]\d*\z/
+            symbol_word.to_i
           else
             symbol_word.to_sym
           end

--- a/lib/fusuma/config/searcher.rb
+++ b/lib/fusuma/config/searcher.rb
@@ -42,7 +42,7 @@ module Fusuma
 
         value = nil
         location.find do |conf|
-          value = search(index, location: conf) if conf[:context] == context
+          value = search(index, location: conf) if ContextMatcher.match?(conf[:context], context)
         end
         value
       end

--- a/lib/fusuma/config/searcher.rb
+++ b/lib/fusuma/config/searcher.rb
@@ -35,14 +35,21 @@ module Fusuma
       def search_with_context(index, location:, context:)
         return nil if location.nil?
 
-        if context == {}
+        # When context is nil or empty, search in no-context config blocks
+        if context.nil? || context == {}
           no_context_conf = location.find { |conf| conf[:context].nil? }
           return no_context_conf ? search(index, location: no_context_conf) : nil
         end
 
+        # When context is specified, search only in context-having config blocks
         value = nil
-        location.find do |conf|
-          value = search(index, location: conf) if ContextMatcher.match?(conf[:context], context)
+        location.each do |conf|
+          next if conf[:context].nil? # skip no-context blocks
+
+          if ContextMatcher.match?(conf[:context], context)
+            value = search(index, location: conf)
+            break if value
+          end
         end
         value
       end

--- a/sig/generated/lib/fusuma/config/context_matcher.rbs
+++ b/sig/generated/lib/fusuma/config/context_matcher.rbs
@@ -1,0 +1,20 @@
+module Fusuma
+  class Config
+    # Matches context conditions for configuration lookup.
+    # Supports AND (multiple keys) and OR (array values) conditions.
+    class ContextMatcher
+      # Check if config context matches request context.
+      # @param config_context [Hash, nil] context defined in YAML config
+      # @param request_context [Hash, nil] context from runtime
+      # @return [Boolean] true if matched
+      # : (Hash[untyped, untyped]?, Hash[untyped, untyped]?) -> bool
+      def self.match?: (Hash[untyped, untyped]?, Hash[untyped, untyped]?) -> bool
+
+      # @param expected [Object] expected value (single or array for OR)
+      # @param actual [Object] actual value from request context
+      # @return [Boolean] true if matched
+      # : (untyped, untyped) -> bool
+      private def self.match_value?: (untyped, untyped) -> bool
+    end
+  end
+end

--- a/sig/generated/lib/fusuma/config/searcher.rbs
+++ b/sig/generated/lib/fusuma/config/searcher.rbs
@@ -56,7 +56,8 @@ module Fusuma
       # : (Hash[untyped, untyped]) { () -> untyped } -> Hash[untyped, untyped]?
       private def self.no_context: (Hash[untyped, untyped]) { () -> untyped } -> Hash[untyped, untyped]?
 
-      # Complete match request context
+      # Match config context with request context using ContextMatcher.
+      # Supports OR condition (array values) and AND condition (multiple keys).
       # @param request_context [Hash]
       # @return [Hash] matched context
       # @return [NilClass] if not matched

--- a/spec/fusuma/config/context_matcher_spec.rb
+++ b/spec/fusuma/config/context_matcher_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "./lib/fusuma/config/context_matcher"
+
+module Fusuma
+  RSpec.describe Config::ContextMatcher do
+    describe ".match?" do
+      context "when config_context is nil" do
+        it "returns true" do
+          expect(described_class.match?(nil, {application: "Chrome"})).to be true
+        end
+      end
+
+      context "when config_context is empty" do
+        it "returns true" do
+          expect(described_class.match?({}, {application: "Chrome"})).to be true
+        end
+      end
+
+      context "when request_context is nil and config_context has conditions" do
+        it "returns false" do
+          expect(described_class.match?({application: "Chrome"}, nil)).to be false
+        end
+      end
+
+      context "when request_context is empty and config_context has conditions" do
+        it "returns false" do
+          expect(described_class.match?({application: "Chrome"}, {})).to be false
+        end
+      end
+
+      context "with single value comparison" do
+        it "returns true when values match" do
+          config_context = {application: "Chrome"}
+          request_context = {application: "Chrome"}
+          expect(described_class.match?(config_context, request_context)).to be true
+        end
+
+        it "returns false when values do not match" do
+          config_context = {application: "Chrome"}
+          request_context = {application: "Firefox"}
+          expect(described_class.match?(config_context, request_context)).to be false
+        end
+
+        it "returns true when boolean values match" do
+          config_context = {thumbsense: true}
+          request_context = {thumbsense: true}
+          expect(described_class.match?(config_context, request_context)).to be true
+        end
+
+        it "returns false when boolean values do not match" do
+          config_context = {thumbsense: true}
+          request_context = {thumbsense: false}
+          expect(described_class.match?(config_context, request_context)).to be false
+        end
+      end
+
+      context "with array value (OR condition)" do
+        it "returns true when actual matches any element" do
+          config_context = {application: ["Chrome", "Firefox"]}
+          request_context = {application: "Chrome"}
+          expect(described_class.match?(config_context, request_context)).to be true
+        end
+
+        it "returns true when actual matches another element" do
+          config_context = {application: ["Chrome", "Firefox"]}
+          request_context = {application: "Firefox"}
+          expect(described_class.match?(config_context, request_context)).to be true
+        end
+
+        it "returns false when actual matches no element" do
+          config_context = {application: ["Chrome", "Firefox"]}
+          request_context = {application: "Safari"}
+          expect(described_class.match?(config_context, request_context)).to be false
+        end
+      end
+
+      context "with multiple keys (AND condition)" do
+        it "returns true when all keys match" do
+          config_context = {thumbsense: true, application: "Chrome"}
+          request_context = {thumbsense: true, application: "Chrome"}
+          expect(described_class.match?(config_context, request_context)).to be true
+        end
+
+        it "returns false when some keys do not match" do
+          config_context = {thumbsense: true, application: "Chrome"}
+          request_context = {thumbsense: false, application: "Chrome"}
+          expect(described_class.match?(config_context, request_context)).to be false
+        end
+
+        it "returns true when request_context has extra keys" do
+          config_context = {application: "Chrome"}
+          request_context = {thumbsense: true, application: "Chrome", extra: "value"}
+          expect(described_class.match?(config_context, request_context)).to be true
+        end
+
+        it "returns false when config key is missing from request_context" do
+          config_context = {thumbsense: true, application: "Chrome"}
+          request_context = {application: "Chrome"}
+          expect(described_class.match?(config_context, request_context)).to be false
+        end
+      end
+
+      context "with combined conditions (AND + OR)" do
+        it "returns true when both AND and OR conditions are satisfied" do
+          config_context = {thumbsense: true, application: ["Chrome", "Firefox"]}
+          request_context = {thumbsense: true, application: "Chrome"}
+          expect(described_class.match?(config_context, request_context)).to be true
+        end
+
+        it "returns false when OR is satisfied but AND is not" do
+          config_context = {thumbsense: true, application: ["Chrome", "Firefox"]}
+          request_context = {thumbsense: false, application: "Chrome"}
+          expect(described_class.match?(config_context, request_context)).to be false
+        end
+
+        it "returns false when AND is satisfied but OR is not" do
+          config_context = {thumbsense: true, application: ["Chrome", "Firefox"]}
+          request_context = {thumbsense: true, application: "Safari"}
+          expect(described_class.match?(config_context, request_context)).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/fusuma/config/index_spec.rb
+++ b/spec/fusuma/config/index_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "./lib/fusuma/config/index"
+
+module Fusuma
+  RSpec.describe Config::Index do
+    describe Config::Index::Key do
+      describe "#symbol" do
+        context "when initialized with Integer" do
+          it "returns Integer" do
+            key = Config::Index::Key.new(3)
+            expect(key.symbol).to eq(3)
+            expect(key.symbol).to be_a(Integer)
+          end
+        end
+
+        context "when initialized with Symbol" do
+          it "returns Symbol" do
+            key = Config::Index::Key.new(:swipe)
+            expect(key.symbol).to eq(:swipe)
+          end
+        end
+
+        context "when initialized with String" do
+          it "returns Symbol for non-numeric string" do
+            key = Config::Index::Key.new("swipe")
+            expect(key.symbol).to eq(:swipe)
+          end
+
+          it "returns Integer for numeric string" do
+            key = Config::Index::Key.new("3")
+            expect(key.symbol).to eq(3)
+            expect(key.symbol).to be_a(Integer)
+          end
+
+          it "returns Integer for multi-digit numeric string" do
+            key = Config::Index::Key.new("42")
+            expect(key.symbol).to eq(42)
+            expect(key.symbol).to be_a(Integer)
+          end
+
+          it "returns Symbol for string with leading zeros" do
+            key = Config::Index::Key.new("03")
+            expect(key.symbol).to eq(:"03")
+          end
+
+          it "returns Symbol for mixed alphanumeric string" do
+            key = Config::Index::Key.new("swipe3")
+            expect(key.symbol).to eq(:swipe3)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `ContextMatcher` class to handle AND/OR context conditions
- Support AND condition: multiple keys in context must all match
- Support OR condition: array values where any element matches
- Convert numeric strings to Integer in `Index::Key` for YAML compatibility

## Use Cases
This enables flexible context-based configuration, especially useful when combining:
- `fusuma-plugin-remap` (key remapping)
- `fusuma-plugin-thumbsense` (thumb detection)
- `fusuma-plugin-appmatcher` (application-specific settings)

### AND condition example
```yaml
---
context:
  thumbsense: true
  application: Alacritty
swipe:
  3:
    left:
      command: 'xdotool key ctrl+t'
```

### OR condition example
```yaml
---
context:
  application:
    - Alacritty
    - Google Chrome
swipe:
  3:
    left:
      command: 'xdotool key ctrl+t'
```

### Combined AND+OR condition example
```yaml
---
context:
  thumbsense: true
  application:
    - Alacritty
    - Google Chrome
swipe:
  3:
    left:
      command: 'xdotool key ctrl+t'
```

## Test plan
- [x] 18 test cases for `ContextMatcher` covering all matching scenarios
- [x] 7 test cases for `Index::Key` numeric string conversion
- [x] Integration tests for Searcher with OR and AND+OR conditions
- [x] All 248 examples pass
- [x] Type check with Steep passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)