### PR TITLE
fix(ci): pin rbs to < 4.0 to work around rbs-inline incompatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,10 @@ gem "standard", require: false
 if RUBY_VERSION >= "3.1.0"
   gem "rbs-trace", require: false
   gem "rbs-inline", require: false
+  # rbs 4.0 made :lower_bound a required keyword on RBS::AST::TypeParam,
+  # which rbs-inline 0.13.0 does not pass. Pin until rbs-inline catches up.
+  # See: https://github.com/iberianpig/fusuma/issues/356
+  gem "rbs", "< 4.0", require: false
 end
 
 # typecheck

--- a/README.md
+++ b/README.md
@@ -408,6 +408,53 @@ Type=Application
 4. Save the file and ensure its permissions are correctly set to be executable.
 5. Restart your system or session to verify that fusuma starts automatically.
 
+### Method 3: systemd user service
+
+Useful when you want fusuma to be supervised by systemd (auto-restart on failure, journal-based logs, start/stop with `systemctl --user`).
+
+1. Check the path where you installed fusuma with `which fusuma`
+2. Create `~/.config/systemd/user/fusuma.service` with the following content. Replace `{path_to_fusuma}` with the path from step 1.
+
+```ini
+[Unit]
+Description=Fusuma (multitouch gesture recognizer)
+Documentation=https://github.com/iberianpig/fusuma
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart={path_to_fusuma}
+Restart=on-failure
+RestartSec=3
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=graphical-session.target
+```
+
+3. Reload, enable, and start the service:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now fusuma.service
+```
+
+4. Verify it is running and inspect logs:
+
+```sh
+systemctl --user status fusuma.service
+journalctl --user -u fusuma.service -f
+```
+
+Notes:
+
+- Do not pass `-d` / `--daemon`; systemd manages the process itself, so fusuma should run in the foreground (`Type=simple`).
+- Make sure your user is in the `input` group (see [Grant permission to read the touchpad device](#grant-permission-to-read-the-touchpad-device)).
+- `graphical-session.target` is started by your desktop session manager. If the service does not start at login, your session may not pull the target in — replace both `graphical-session.target` lines with `default.target`, or start the service manually with `systemctl --user start fusuma.service`.
+- If you installed fusuma via a Ruby version manager (rbenv, asdf, mise, etc.), `which fusuma` returns a shim that relies on the manager's `PATH`. Resolve the real binary with `readlink -f $(which fusuma)` and use that as `ExecStart`.
+
 ## Fusuma Plugins
 
 Fusuma's functionality can be extended with a variety of plugins. Below is a list of available plugins along with their purposes:


### PR DESCRIPTION
## Summary
- rbs 4.0 made `:lower_bound` a required keyword on `RBS::AST::TypeParam#initialize`, but the latest released `rbs-inline` (v0.13.0, 2026-02-12) still calls `TypeParam.new` without it (`lib/rbs/inline/ast/annotations.rb:58`).
- Since `Gemfile.lock` is gitignored (gem repo convention), every CI run resolves to the latest `rbs` and picks up the breaking change, failing `rake default` → `rbs:generate` → `rbs:inline` on Ruby 3.2 / 3.3.
- Pin `rbs < 4.0` in the Gemfile until rbs-inline catches up. (Confirmed on GitHub: rbs-inline `main` also still lacks the fix and its gemspec is still `rbs >= 3.8.0`, so there is nothing to wait for short-term.)

Closes #356

## Test plan
- [x] `bundle install` resolves `rbs` to 3.10.4 locally
- [x] `bundle exec rake default` passes locally (rbs validate / steep check / rspec all green)
- [x] CI passes on Ruby 3.0 / 3.2 / 3.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)