### PR TITLE
feat: add per-input `enabled?` to skip inputs via config

### DIFF
--- a/lib/fusuma.rb
+++ b/lib/fusuma.rb
@@ -67,7 +67,10 @@ module Fusuma
 
     #: () -> void
     def initialize_plugins
-      @inputs = Plugin::Inputs::Input.plugins.map do |cls|
+      # enabled? is checked on the class before instantiation: some input
+      # plugins fork subprocesses or grab devices in #initialize, so a
+      # disabled input must not be instantiated at all.
+      @inputs = Plugin::Inputs::Input.plugins.select(&:enabled?).map do |cls|
         cls.ancestors.include?(Singleton) ? cls.instance : cls.new
       end
       @filters = Plugin::Filters::Filter.plugins.map(&:new)

--- a/lib/fusuma/config/index.rb
+++ b/lib/fusuma/config/index.rb
@@ -54,6 +54,7 @@ module Fusuma
           @skippable = skippable
         end
 
+        #: () -> String
         def to_s
           if @skippable
             "#{@symbol}(skippable)"

--- a/lib/fusuma/plugin/base.rb
+++ b/lib/fusuma/plugin/base.rb
@@ -39,7 +39,7 @@ module Fusuma
 
       # config parameter name and Type of the value of parameter
       # @return [Hash]
-      #: () -> Hash[untyped, untyped]
+      #: () -> Hash[Symbol, Class | Array[Class]]
       def config_param_types
         raise NotImplementedError, "override #{self.class.name}##{__method__}"
       end

--- a/lib/fusuma/plugin/base.rb
+++ b/lib/fusuma/plugin/base.rb
@@ -39,6 +39,7 @@ module Fusuma
 
       # config parameter name and Type of the value of parameter
       # @return [Hash]
+      #: () -> Hash[untyped, untyped]
       def config_param_types
         raise NotImplementedError, "override #{self.class.name}##{__method__}"
       end
@@ -58,24 +59,55 @@ module Fusuma
 
         return params unless key
 
+        value = params.fetch(key, nil)
         @config_params["#{config_index.cache_key},#{key}"] =
-          params.fetch(key, nil).tap do |val|
-            next if val.nil?
-
-            # NOTE: Type checking for config.yml
-            param_types = Array(config_param_types.fetch(key))
-
-            next if param_types.any? { |klass| val.is_a?(klass) }
-
-            MultiLogger.error("Please fix config.yml")
-            MultiLogger.error("`#{config_index.keys.join(".")}.#{key}` should be #{param_types.join(" OR ")}.")
-            exit 1
+          if value.nil?
+            # Not configured: skip type checking (and thus config_param_types,
+            # which subclasses without params legitimately leave unimplemented).
+            value
+          else
+            self.class.validate_param_type!(config_index, key, value, config_param_types.fetch(key))
           end
       end
 
       #: () -> Fusuma::Config::Index
       def config_index
-        @config_index ||= Config::Index.new(self.class.name.gsub("Fusuma::", "").underscore.split("/"))
+        @config_index ||= self.class.config_index
+      end
+
+      # Class-level config lookup with type validation, usable BEFORE
+      # instantiation (e.g. by Inputs::Input.enabled?, which must decide
+      # whether to instantiate at all). Unlike the instance #config_params
+      # it takes the accepted types explicitly, since #config_param_types
+      # is defined per instance and not available before #initialize.
+      #: (Symbol, untyped) -> untyped
+      def self.config_param(key, types)
+        index = config_index
+        value = Config.instance.fetch_config_params(key, index).fetch(key, nil)
+        validate_param_type!(index, key, value, types)
+      end
+
+      #: () -> Fusuma::Config::Index
+      def self.config_index
+        Config::Index.new(name.gsub("Fusuma::", "").underscore.split("/"))
+      end
+
+      # Validate that a config value matches one of the accepted types,
+      # printing a helpful message and exiting on mismatch. A nil value
+      # passes through (meaning "not configured"). Shared by the instance
+      # #config_params and the class .config_param so the error format
+      # stays identical.
+      #: (Fusuma::Config::Index, Symbol, untyped, untyped) -> untyped
+      def self.validate_param_type!(index, key, value, types)
+        return value if value.nil?
+
+        # NOTE: Type checking for config.yml
+        param_types = Array(types)
+        return value if param_types.any? { |klass| value.is_a?(klass) }
+
+        MultiLogger.error("Please fix config.yml")
+        MultiLogger.error("`#{index.keys.join(".")}.#{key}` should be #{param_types.join(" OR ")}.")
+        exit 1
       end
     end
   end

--- a/lib/fusuma/plugin/buffers/timer_buffer.rb
+++ b/lib/fusuma/plugin/buffers/timer_buffer.rb
@@ -10,6 +10,7 @@ module Fusuma
         DEFAULT_SOURCE = "timer_input"
         DEFAULT_SECONDS_TO_KEEP = 3
 
+        #: () -> Hash[untyped, untyped]
         def config_param_types
           {
             source: [String],

--- a/lib/fusuma/plugin/inputs/input.rb
+++ b/lib/fusuma/plugin/inputs/input.rb
@@ -26,18 +26,13 @@ module Fusuma
         # Checked on the class BEFORE instantiation: some input plugins
         # have side effects in #initialize (forking subprocesses, grabbing
         # devices), so a disabled input must never be instantiated at all.
+        #
+        # The value is type-checked via Base.config_param: a non-boolean
+        # `enabled` (e.g. the quoted string "false") exits with a helpful
+        # message rather than being silently treated as enabled.
         #: () -> bool
         def self.enabled?
-          config_enabled != false
-        end
-
-        # The `enabled` value configured for this plugin, or nil when not
-        # set. Class-level equivalent of config_params(:enabled): the
-        # config index is derived from the class name alone.
-        #: () -> bool?
-        def self.config_enabled
-          index = Config::Index.new(name.gsub("Fusuma::", "").underscore.split("/"))
-          Config.instance.fetch_config_params(:enabled, index).fetch(:enabled, nil)
+          config_param(:enabled, [TrueClass, FalseClass]) != false
         end
 
         # Wait multiple inputs until it becomes readable

--- a/lib/fusuma/plugin/inputs/input.rb
+++ b/lib/fusuma/plugin/inputs/input.rb
@@ -17,6 +17,29 @@ module Fusuma
 
         attr_reader :tag
 
+        # Whether this input participates in the input loop. Enabled by
+        # default; set `enabled: false` under the plugin in config.yml to
+        # skip it (e.g. to turn off libinput_command_input when another
+        # input plugin provides events). Plugins may override to opt out
+        # by default.
+        #
+        # Checked on the class BEFORE instantiation: some input plugins
+        # have side effects in #initialize (forking subprocesses, grabbing
+        # devices), so a disabled input must never be instantiated at all.
+        #: () -> bool
+        def self.enabled?
+          config_enabled != false
+        end
+
+        # The `enabled` value configured for this plugin, or nil when not
+        # set. Class-level equivalent of config_params(:enabled): the
+        # config index is derived from the class name alone.
+        #: () -> bool?
+        def self.config_enabled
+          index = Config::Index.new(name.gsub("Fusuma::", "").underscore.split("/"))
+          Config.instance.fetch_config_params(:enabled, index).fetch(:enabled, nil)
+        end
+
         # Wait multiple inputs until it becomes readable
         # @param inputs [Array<Input>]
         # @return [Event]

--- a/lib/fusuma/plugin/inputs/timer_input.rb
+++ b/lib/fusuma/plugin/inputs/timer_input.rb
@@ -12,6 +12,7 @@ module Fusuma
 
         DEFAULT_INTERVAL = 5
         EPSILON_TIME = 0.02
+        #: () -> Hash[untyped, untyped]
         def config_param_types
           {
             interval: [Float]

--- a/spec/fusuma/plugin/base_spec.rb
+++ b/spec/fusuma/plugin/base_spec.rb
@@ -69,6 +69,29 @@ module Fusuma
           expect(@dummy_plugin.config_index).to be_a Config::Index
         end
       end
+
+      describe ".config_index" do
+        it "returns an index derived from the class name (no instance needed)" do
+          expect(DummyPlugin.config_index).to be_a Config::Index
+        end
+      end
+
+      describe ".config_param" do
+        it "fetches a type-valid value before instantiation" do
+          expect(DummyPlugin.config_param(:dummy_string, String)).to eq("dummy")
+        end
+
+        it "returns nil when the key is not configured" do
+          expect(DummyPlugin.config_param(:missing, String)).to be_nil
+        end
+
+        it "exits with a helpful error on a type mismatch" do
+          allow(MultiLogger).to receive(:error)
+          expect { DummyPlugin.config_param(:dummy_string, [TrueClass, FalseClass]) }
+            .to raise_error(SystemExit)
+          expect(MultiLogger).to have_received(:error).with(/should be/)
+        end
+      end
     end
   end
 end

--- a/spec/fusuma/plugin/inputs/input_spec.rb
+++ b/spec/fusuma/plugin/inputs/input_spec.rb
@@ -78,6 +78,57 @@ module Fusuma
           it { is_expected.to eq("dummy") }
         end
       end
+
+      # enabled? is a CLASS method, checked before instantiation: input
+      # plugins may fork subprocesses or grab devices in #initialize, so a
+      # disabled input must never be instantiated.
+      RSpec.describe DummyInput do
+        around do |example|
+          example.run
+          Config.custom_path = nil
+        end
+
+        describe ".enabled?" do
+          context "when enabled is not set" do
+            before do
+              ConfigHelper.load_config_yml = <<~CONFIG
+                plugin:
+                  inputs:
+                    dummy_input:
+                      dummy: dummy
+              CONFIG
+            end
+
+            it { expect(described_class.enabled?).to be true }
+          end
+
+          context "when enabled: false" do
+            before do
+              ConfigHelper.load_config_yml = <<~CONFIG
+                plugin:
+                  inputs:
+                    dummy_input:
+                      enabled: false
+              CONFIG
+            end
+
+            it { expect(described_class.enabled?).to be false }
+          end
+
+          context "when enabled: true" do
+            before do
+              ConfigHelper.load_config_yml = <<~CONFIG
+                plugin:
+                  inputs:
+                    dummy_input:
+                      enabled: true
+              CONFIG
+            end
+
+            it { expect(described_class.enabled?).to be true }
+          end
+        end
+      end
     end
   end
 end

--- a/spec/fusuma/plugin/inputs/input_spec.rb
+++ b/spec/fusuma/plugin/inputs/input_spec.rb
@@ -127,6 +127,23 @@ module Fusuma
 
             it { expect(described_class.enabled?).to be true }
           end
+
+          context "when enabled is a non-boolean (e.g. quoted string)" do
+            before do
+              ConfigHelper.load_config_yml = <<~CONFIG
+                plugin:
+                  inputs:
+                    dummy_input:
+                      enabled: "false"
+              CONFIG
+              allow(MultiLogger).to receive(:error)
+            end
+
+            it "exits with a helpful type-validation error" do
+              expect { described_class.enabled? }.to raise_error(SystemExit)
+              expect(MultiLogger).to have_received(:error).with(/should be/)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
## What

Adds a per-input `enabled?` mechanism so an input plugin can be turned off from `config.yml`:

```yaml
plugin:
  inputs:
    libinput_command_input:
      enabled: false
```

Default stays enabled, so existing configs are unaffected.

## Why

There's currently no way to disable a bundled/installed input plugin. fusuma instantiates every registered input and reads them all in `IO.select`, so an alternative input plugin can't replace `libinput_command_input` — both run and gestures get detected twice.

This lets a user disable one input while another provides events (e.g. an input plugin that reads libinput directly, instead of spawning `libinput debug-events`).

## How

- `Inputs::Input.enabled?` is a **class method**, evaluated **before instantiation** in `Runner#initialize_plugins` (`plugins.select(&:enabled?).map { … new }`).
- This ordering matters: some input plugins have side effects in `#initialize` — e.g. `fusuma-plugin-remap` forks a subprocess and grabs input devices. Filtering *instances* after `new` would leave those side effects running with nobody reading their pipes. Filtering *classes* first means a disabled input is never instantiated at all.
- The config lookup mirrors `config_params(:enabled)` at the class level (the config index derives from the class name).

## Tests

- New `.enabled?` specs in `spec/fusuma/plugin/inputs/input_spec.rb` (default / `enabled: false` / `enabled: true`).
- Full suite green: `267 examples, 0 failures, 5 pending`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
