### PR TITLE
refactor: remove redundant partial_match_context

### DIFF
--- a/lib/fusuma/config/searcher.rb
+++ b/lib/fusuma/config/searcher.rb
@@ -104,7 +104,7 @@ module Fusuma
           @context = before
         end
 
-        CONTEXT_SEARCH_ORDER = [:no_context, :complete_match_context, :partial_match_context]
+        CONTEXT_SEARCH_ORDER = [:no_context, :complete_match_context]
         # Return a matching context from config
         # @params request_context [Hash]
         # @return [Hash]
@@ -115,7 +115,7 @@ module Fusuma
           # 2. complete_match_context: config[:context] matches request_context
           #    - Supports OR condition (array values)
           #    - Supports AND condition (multiple keys)
-          # 3. partial_match_context: config[:context] partially matches request_context
+          #    - Supports partial match (config context is subset of request context)
           fallbacks.find do |method|
             result = send(method, request_context, &block)
             return result if result
@@ -144,23 +144,6 @@ module Fusuma
             return config[:context] if with_context(config[:context], &block)
           end
           nil
-        end
-
-        # One of multiple request contexts matched
-        # @param request_context [Hash]
-        # @return [Hash] matched context
-        # @return [NilClass] if not matched
-        #: (Hash[untyped, untyped]) { () -> untyped } -> Hash[untyped, untyped]?
-        def partial_match_context(request_context, &block)
-          if request_context.keys.size > 1
-            Config.instance.keymap.each do |config|
-              next if config[:context].nil?
-
-              next unless config[:context].all? { |k, v| request_context[k] == v }
-              return config[:context] if with_context(config[:context], &block)
-            end
-            nil
-          end
         end
 
         # Search context for plugin

--- a/lib/fusuma/config/searcher.rb
+++ b/lib/fusuma/config/searcher.rb
@@ -106,8 +106,8 @@ module Fusuma
 
         CONTEXT_SEARCH_ORDER = [:no_context, :complete_match_context]
         # Return a matching context from config
-        # @params request_context [Hash]
-        # @return [Hash]
+        # @param request_context [Hash]
+        # @return [Hash, NilClass] matched context (nil if not matched)
         #: (Hash[untyped, untyped], ?Array[untyped]) { () -> untyped } -> Hash[untyped, untyped]?
         def find_context(request_context, fallbacks = CONTEXT_SEARCH_ORDER, &block)
           # Search in blocks in the following order.

--- a/sig/generated/lib/fusuma/config/searcher.rbs
+++ b/sig/generated/lib/fusuma/config/searcher.rbs
@@ -64,13 +64,6 @@ module Fusuma
       # : (Hash[untyped, untyped]) { () -> untyped } -> Hash[untyped, untyped]?
       private def self.complete_match_context: (Hash[untyped, untyped]) { () -> untyped } -> Hash[untyped, untyped]?
 
-      # One of multiple request contexts matched
-      # @param request_context [Hash]
-      # @return [Hash] matched context
-      # @return [NilClass] if not matched
-      # : (Hash[untyped, untyped]) { () -> untyped } -> Hash[untyped, untyped]?
-      private def self.partial_match_context: (Hash[untyped, untyped]) { () -> untyped } -> Hash[untyped, untyped]?
-
       # Search context for plugin
       # If the plugin_defaults key is a complete match,
       # it is the default value for that plugin, so it is postponed.

--- a/sig/prototype/lib/fusuma/config/searcher.rbs
+++ b/sig/prototype/lib/fusuma/config/searcher.rbs
@@ -3,7 +3,7 @@ module Fusuma
   class Config
     # Search config.yml
     class Searcher
-      CONTEXT_SEARCH_ORDER: ::Array[:no_context | :complete_match_context | :partial_match_context]
+      CONTEXT_SEARCH_ORDER: ::Array[:no_context | :complete_match_context]
       self.@context: untyped
 
       @cache: untyped


### PR DESCRIPTION
## Summary

Refactoring that removes the redundant `partial_match_context` from `Config::Searcher`'s context lookup.

## Background

`ContextMatcher.match?` (`lib/fusuma/config/context_matcher.rb:14`) already supports **partial matching** (config context as a subset of request context). Its implementation, `config_context.all? { |k, v| match_value?(v, request_context[k]) }`, only inspects the keys defined on the config side, so a config context that is a subset of the request context still matches.

Because `complete_match_context` goes through `ContextMatcher.match?`, and it runs before `partial_match_context` in `CONTEXT_SEARCH_ORDER`, the dedicated `partial_match_context` method could never produce a match that `complete_match_context` had not already found. It was pure dead code.

## Changes

- Simplify `CONTEXT_SEARCH_ORDER` from `[:no_context, :complete_match_context, :partial_match_context]` to `[:no_context, :complete_match_context]`
- Remove the `partial_match_context` method
- Update the `find_context` comment to note that partial matching is covered by `complete_match_context`
- Regenerate RBS signatures (drop the stale `partial_match_context` reference)

## Verification

- All tests pass (264 examples, 0 failures, 5 pending)
- `searcher` coverage 100%
- `rake rbs:validate` passes
- `steep check` reports no type errors
- `standardrb` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
