### PR TITLE
Batch of 26 small improvements: bug fixes, specs, RBS, docs, CI

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -11,10 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
 
     steps:
     - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 In order to use the Fusuma console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. Fusuma requires Ruby 2.3+. You may choose to
+1. Install Ruby. Fusuma requires Ruby 2.7+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).
@@ -40,25 +40,31 @@ $ bundle exec rspec
 
 The project uses [YARD](https://github.com/lsegal/yard) for generating documentation.  
 
+YARD is not included in the project's Gemfile, so install it first:
+
+``` sh
+$ gem install yard
+```
+
 If you're not sure about YARD, please refer to [YARD cheatsheet](https://gist.github.com/phansch/db18a595d2f5f1ef16646af72fe1fb0e).
 
 To run the Fusuma documentation tests:
 
 ``` sh
-$ bundle exec yard --fail-on-warning
+$ yard --fail-on-warning
 ```
 
 To check Fusuma documents with running local server:
 
 ```
-$ bundle exec yard server
+$ yard server
 ```
 Then open (http://localhost:8808/)
 
 ## Coding Style
 
 Please follow the established coding style in the library.
-The style is is largely based on [The Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide).
+The style is largely based on [Standard Ruby](https://github.com/standardrb/standard).
 
 You can check your code against these rules by running Rubocop like so:
 

--- a/README.md
+++ b/README.md
@@ -268,12 +268,12 @@ If you have a nice configuration, please share `~/.config/fusuma/config.yml` wit
 
 ### Threshold and Interval
 
-if `command:` properties are blank, the swipe/pinch/hold doesn't execute command.
+if `command:` properties are blank, the swipe/pinch/rotate/hold doesn't execute command.
 
-`threshold:` is sensitivity to swipe/pinch/hold. Default value is 1.
+`threshold:` is sensitivity to swipe/pinch/rotate/hold. Default value is 1.
 If the swipe's threshold is `0.5`, shorten swipe-length by half.
 
-`interval:` is delay between swipes/pinches/hold. Default value is 1.
+`interval:` is delay between swipes/pinches/rotations/hold. Default value is 1.
 If the swipe's interval is `0.5`, shorten swipe-interval by half to recognize a next swipe.
 
 ### Example of `threshold:` / `interval:` settings
@@ -310,7 +310,7 @@ There are three priorities of `threshold:` and `interval:`.
 The individual `threshold:` and `interval:` settings (under "direction") have a higher priority than the global one (under "root")
 
 1. child elements in the direction (left/right/down/up → threshold/interval)
-1. root child elements (threshold/interval → swipe/pinch/hold)
+1. root child elements (threshold/interval → swipe/pinch/rotate/hold)
 1. default value (= 1)
 
 ### `command:` property for assigning commands

--- a/README.md
+++ b/README.md
@@ -365,7 +365,8 @@ swipe:
 - `-l`, `--list-devices` : List available devices
 - `-v`, `--verbose` : Show details about the results of running fusuma
 - `--version` : Show fusuma version
-- `--log-file=path/to/file` : Set path of log file
+- `--log=path/to/file` : Print logs to file
+- `--show-config` : Show config as YAML format which is loaded internally
 
 ### Specify touchpads by device name
 Set the following options to recognize multi-touch gestures only for the specified touchpad device.

--- a/lib/fusuma.rb
+++ b/lib/fusuma.rb
@@ -36,6 +36,10 @@ module Fusuma
 
         load_custom_config(option[:config_path])
 
+        if (filters = Config.search(Config::Index.new([:log_filter])))
+          MultiLogger.instance.ignore_pattern = Regexp.union(Array(filters).map(&:to_s))
+        end
+
         Environment.dump_information
         Kernel.exit(0) if option[:version]
 

--- a/lib/fusuma/config.rb
+++ b/lib/fusuma/config.rb
@@ -26,6 +26,7 @@ module Fusuma
         instance.search(index)
       end
 
+      #: (Fusuma::Config::Index) -> Symbol?
       def find_execute_key(index)
         instance.find_execute_key(index)
       end
@@ -127,6 +128,7 @@ module Fusuma
 
     # @param index [Config::Index]
     # @return Symbol
+    #: (Fusuma::Config::Index) -> Symbol?
     def find_execute_key(index)
       @execute_keys ||= Plugin::Executors::Executor.plugins.map do |executor|
         executor.new.execute_keys
@@ -172,6 +174,7 @@ module Fusuma
       File.expand_path "~/.config/#{filename}"
     end
 
+    #: (String) -> String
     def expand_default_path(filename)
       File.expand_path "../../#{filename}", __FILE__
     end

--- a/lib/fusuma/config.rb
+++ b/lib/fusuma/config.rb
@@ -89,7 +89,7 @@ module Fusuma
       fallbacks = [:no_context, :plugin_default_context]
       Config::Searcher.find_context(request_context, fallbacks) do
         ret = Config.search(base)
-        if ret&.key?(key)
+        if ret.is_a?(Hash) && ret.key?(key)
           return ret
         end
       end

--- a/lib/fusuma/config.rb
+++ b/lib/fusuma/config.rb
@@ -100,14 +100,15 @@ module Fusuma
     # @raise [InvalidFileError] If check does not pass
     #: (String) -> Array[Hash[Symbol, untyped]]
     def validate(path)
+      content = File.read(path)
       duplicates = []
-      YAMLDuplicationChecker.check(File.read(path), path) do |ignored, duplicate| # steep:ignore UnexpectedBlockGiven
+      YAMLDuplicationChecker.check(content, path) do |ignored, duplicate| # steep:ignore UnexpectedBlockGiven
         MultiLogger.error "#{path}: #{ignored.value} is duplicated"
         duplicates << duplicate.value
       end
       raise InvalidFileError, "Detect duplicate keys #{duplicates}" unless duplicates.empty?
 
-      yamls = YAML.load_stream(File.read(path)).compact # steep:ignore NoMethod
+      yamls = YAML.load_stream(content).compact # steep:ignore NoMethod
       yamls.map do |yaml|
         raise InvalidFileError, "Invalid config.yml: #{path}" unless yaml.is_a? Hash
 

--- a/lib/fusuma/config/index.rb
+++ b/lib/fusuma/config/index.rb
@@ -25,6 +25,7 @@ module Fusuma
       attr_reader :keys #: Array[Key]
       attr_reader :cache_key #: Symbol | Integer
 
+      #: () -> Array[untyped]
       def to_s
         @keys.map(&:inspect)
       end

--- a/lib/fusuma/config/searcher.rb
+++ b/lib/fusuma/config/searcher.rb
@@ -24,7 +24,7 @@ module Fusuma
 
         next_index = Index.new(index.keys.drop(1))
 
-        next_location_cadidates(location, key).each do |next_location|
+        next_location_candidates(location, key).each do |next_location|
           result = search(next_index, location: next_location)
           return result if result
         end
@@ -82,7 +82,7 @@ module Fusuma
       #  1. look up location with key
       #  2. skip the key and go to child location
       #: (Hash[untyped, untyped], Fusuma::Config::Index::Key) -> Array[untyped]
-      def next_location_cadidates(location, key)
+      def next_location_candidates(location, key)
         [
           location[key.symbol],
           key.skippable ? location : nil

--- a/lib/fusuma/hash_support.rb
+++ b/lib/fusuma/hash_support.rb
@@ -4,11 +4,15 @@
 # @rbs generic unchecked out V
 class Hash
   # activesupport-5.2.0/lib/active_support/core_ext/hash/deep_merge.rb
+  # Keep untyped: rbs-trace would record concrete types here that conflict
+  # with the block type of the core Hash#merge! signature under steep.
+  #: (untyped other_hash) ?{ (?) -> untyped } -> untyped
   def deep_merge(other_hash, &block)
     dup.deep_merge!(other_hash, &block)
   end
 
   # Same as +deep_merge+, but modifies +self+.
+  #: (untyped other_hash) ?{ (?) -> untyped } -> untyped
   def deep_merge!(other_hash, &block)
     merge!(other_hash) do |key, this_val, other_val|
       if this_val.is_a?(Hash) && other_val.is_a?(Hash)
@@ -21,6 +25,7 @@ class Hash
     end
   end
 
+  #: () -> Hash[untyped, untyped]
   def deep_stringify_keys
     deep_transform_keys(&:to_s)
   end

--- a/lib/fusuma/libinput_command.rb
+++ b/lib/fusuma/libinput_command.rb
@@ -24,12 +24,13 @@ module Fusuma
     end
 
     # @return [Boolean]
+    #: () -> bool
     def libinput_1_27_0_or_later?
       Gem::Version.new(version) >= Gem::Version.new("1.27.0")
     end
 
     # @return [String]
-    #: () -> String?
+    #: () -> String
     def version
       # version_command prints "1.6.3\n"
       @version ||= `#{version_command}`.strip
@@ -53,14 +54,14 @@ module Fusuma
     end
 
     # @return [Integer] return a latest line libinput debug-events
-    #: (StringIO) -> Array[untyped]
+    #: (IO) -> Array[untyped]
     def debug_events(writer)
       Open3.pipeline_start([debug_events_with_options], ["grep -v POINTER_ --line-buffered"], out: writer, in: "/dev/null")
     end
 
     # @return [String] command
     # @raise [SystemExit]
-    #: () -> String?
+    #: () -> String
     def version_command
       if @libinput_command
         "#{@libinput_command} --version"
@@ -116,6 +117,7 @@ module Fusuma
     #
     #   which('ruby') #=> /usr/bin/ruby
     # @return [String, nil]
+    #: (String) -> String?
     def which(command)
       exts = ENV["PATHEXT"] ? ENV["PATHEXT"].split(";") : [""]
       ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|

--- a/lib/fusuma/multi_logger.rb
+++ b/lib/fusuma/multi_logger.rb
@@ -9,8 +9,11 @@ module Fusuma
   class MultiLogger < Logger
     include Singleton
 
+    DEFAULT_IGNORE_PATTERN = /timer_input/ #: Regexp
+
     attr_reader :err_logger
     attr_accessor :debug_mode
+    attr_accessor :ignore_pattern #: Regexp
 
     class << self
       attr_writer :filepath
@@ -49,6 +52,7 @@ module Fusuma
       end
       @err_logger = Logger.new($stderr)
       @debug_mode = false
+      @ignore_pattern = DEFAULT_IGNORE_PATTERN
     end
 
     #: (untyped) -> void
@@ -77,19 +81,16 @@ module Fusuma
 
     private
 
-    #: (String) -> bool
+    #: (untyped) -> bool
     def ignore_pattern?(msg)
-      # TODO: configurable from config.yml
-      # pattern = /timer_input|remap_touchpad_input|thumbsense context|libinput_command_input/
-      pattern = /timer_input/
       case msg
       when Hash
         e = msg.values.find { |v| v.is_a? Fusuma::Plugin::Events::Event }
         return false unless e
 
-        e.tag.match?(pattern)
+        e.tag.match?(@ignore_pattern)
       when String
-        msg.match?(pattern)
+        msg.match?(@ignore_pattern)
       else
         false
       end

--- a/lib/fusuma/plugin/buffers/gesture_buffer.rb
+++ b/lib/fusuma/plugin/buffers/gesture_buffer.rb
@@ -134,6 +134,7 @@ module Fusuma
         #  event_buffer.gesture
         #  => 'swipe'
         # @return [String]
+        #: () -> String
         def gesture
           @events.last.record.gesture
         end

--- a/lib/fusuma/plugin/buffers/timer_buffer.rb
+++ b/lib/fusuma/plugin/buffers/timer_buffer.rb
@@ -10,6 +10,7 @@ module Fusuma
         DEFAULT_SOURCE = "timer_input"
         DEFAULT_SECONDS_TO_KEEP = 3
 
+        #: () -> Hash[untyped, untyped]
         def config_param_types
           {
             source: [String],
@@ -27,6 +28,7 @@ module Fusuma
           self
         end
 
+        #: (?current_time: Time) -> void
         def clear_expired(current_time: Time.now)
           @seconds_to_keep ||= config_params(:seconds_to_keep) || DEFAULT_SECONDS_TO_KEEP
           @events.each do |e|

--- a/lib/fusuma/plugin/detectors/detector.rb
+++ b/lib/fusuma/plugin/detectors/detector.rb
@@ -62,6 +62,41 @@ module Fusuma
         def first_time?
           @last_time.nil?
         end
+
+        private
+
+        # Detect the current status of the gesture from the buffer
+        # @param gesture_buffer [Buffers::GestureBuffer]
+        # @param updating_events [Array<Events::Event>]
+        # @return [String] "begin", "update", "end", or the last record's status
+        #: (untyped, Array[untyped]) -> String
+        def detect_status(gesture_buffer, updating_events)
+          case gesture_buffer.events.last.record.status
+          when "end"
+            "end"
+          when "update"
+            if updating_events.length == 1
+              "begin"
+            else
+              "update"
+            end
+          else
+            gesture_buffer.events.last.record.status
+          end
+        end
+
+        # Select the delta of the last relevant event depending on the status
+        # @param gesture_buffer [Buffers::GestureBuffer]
+        # @param status [String]
+        # @return [Events::Records::GestureRecord::Delta]
+        #: (untyped, String) -> untyped
+        def last_delta(gesture_buffer, status)
+          if status == "end"
+            gesture_buffer.events[-2].record.delta
+          else
+            gesture_buffer.events.last.record.delta
+          end
+        end
       end
     end
   end

--- a/lib/fusuma/plugin/detectors/detector.rb
+++ b/lib/fusuma/plugin/detectors/detector.rb
@@ -62,6 +62,22 @@ module Fusuma
         def first_time?
           @last_time.nil?
         end
+
+        private
+
+        # @param index [Config::Index]
+        # @return [Float, Integer]
+        #: (index: Fusuma::Config::Index) -> (Float | Integer)
+        def threshold(index:)
+          @threshold ||= {}
+          @threshold[index.cache_key] ||= begin
+            keys_specific = Config::Index.new [*index.keys, "threshold"]
+            keys_global = Config::Index.new ["threshold", type]
+            config_value = Config.search(keys_specific) ||
+              Config.search(keys_global) || 1
+            self.class::BASE_THRESHOLD * config_value
+          end
+        end
       end
     end
   end

--- a/lib/fusuma/plugin/detectors/hold_detector.rb
+++ b/lib/fusuma/plugin/detectors/hold_detector.rb
@@ -133,18 +133,6 @@ module Fusuma
           end
           false
         end
-
-        #: (index: Fusuma::Config::Index) -> Float
-        def threshold(index:)
-          @threshold ||= {}
-          @threshold[index.cache_key] ||= begin
-            keys_specific = Config::Index.new [*index.keys, "threshold"]
-            keys_global = Config::Index.new ["threshold", type]
-            config_value = Config.search(keys_specific) ||
-              Config.search(keys_global) || 1
-            BASE_THRESHOLD * config_value
-          end
-        end
       end
     end
   end

--- a/lib/fusuma/plugin/detectors/hold_detector.rb
+++ b/lib/fusuma/plugin/detectors/hold_detector.rb
@@ -49,7 +49,7 @@ module Fusuma
           when "end"
             "end"
           else
-            last_record = last_hold.record.status
+            last_record = last_hold.record
             raise "Unexpected Status:#{last_record.status} in #{last_record}"
           end
 

--- a/lib/fusuma/plugin/detectors/pinch_detector.rb
+++ b/lib/fusuma/plugin/detectors/pinch_detector.rb
@@ -27,18 +27,7 @@ module Fusuma
 
           finger = gesture_buffer.finger
 
-          status = case gesture_buffer.events.last.record.status
-          when "end"
-            "end"
-          when "update"
-            if updating_events.length == 1
-              "begin"
-            else
-              "update"
-            end
-          else
-            gesture_buffer.events.last.record.status
-          end
+          status = detect_status(gesture_buffer, updating_events)
 
           prev_event, event = if status == "end"
             [

--- a/lib/fusuma/plugin/detectors/pinch_detector.rb
+++ b/lib/fusuma/plugin/detectors/pinch_detector.rb
@@ -139,18 +139,6 @@ module Fusuma
           quantity >= threshold(index: index)
         end
 
-        #: (index: Fusuma::Config::Index) -> Float
-        def threshold(index:)
-          @threshold ||= {}
-          @threshold[index.cache_key] ||= begin
-            keys_specific = Config::Index.new [*index.keys, "threshold"]
-            keys_global = Config::Index.new ["threshold", type]
-            config_value = Config.search(keys_specific) ||
-              Config.search(keys_global) || 1
-            BASE_THRESHOLD * config_value
-          end
-        end
-
         # direction of gesture
         class Direction
           IN = "in"

--- a/lib/fusuma/plugin/detectors/rotate_detector.rb
+++ b/lib/fusuma/plugin/detectors/rotate_detector.rb
@@ -31,24 +31,8 @@ module Fusuma
 
           finger = gesture_buffer.finger
 
-          status = case gesture_buffer.events.last.record.status
-          when "end"
-            "end"
-          when "update"
-            if updating_events.length == 1
-              "begin"
-            else
-              "update"
-            end
-          else
-            gesture_buffer.events.last.record.status
-          end
-
-          delta = if status == "end"
-            gesture_buffer.events[-2].record.delta
-          else
-            gesture_buffer.events.last.record.delta
-          end
+          status = detect_status(gesture_buffer, updating_events)
+          delta = last_delta(gesture_buffer, status)
 
           repeat_direction = Direction.new(angle: delta.rotate).to_s
           repeat_quantity = Quantity.new(angle: delta.rotate).to_f

--- a/lib/fusuma/plugin/detectors/rotate_detector.rb
+++ b/lib/fusuma/plugin/detectors/rotate_detector.rb
@@ -124,18 +124,6 @@ module Fusuma
           quantity > threshold(index: index)
         end
 
-        #: (index: Fusuma::Config::Index) -> Float
-        def threshold(index:)
-          @threshold ||= {}
-          @threshold[index.cache_key] ||= begin
-            keys_specific = Config::Index.new [*index.keys, "threshold"]
-            keys_global = Config::Index.new ["threshold", type]
-            config_value = Config.search(keys_specific) ||
-              Config.search(keys_global) || 1
-            BASE_THRESHOLD * config_value
-          end
-        end
-
         # direction of gesture
         class Direction
           CLOCKWISE = "clockwise"

--- a/lib/fusuma/plugin/detectors/swipe_detector.rb
+++ b/lib/fusuma/plugin/detectors/swipe_detector.rb
@@ -31,24 +31,8 @@ module Fusuma
           oneshot_move_y = gesture_buffer.sum_last10_attrs(:move_y) / updating_time
 
           finger = gesture_buffer.finger
-          status = case gesture_buffer.events.last.record.status
-          when "end"
-            "end"
-          when "update"
-            if updating_events.length == 1
-              "begin"
-            else
-              "update"
-            end
-          else
-            gesture_buffer.events.last.record.status
-          end
-
-          delta = if status == "end"
-            gesture_buffer.events[-2].record.delta
-          else
-            gesture_buffer.events.last.record.delta
-          end
+          status = detect_status(gesture_buffer, updating_events)
+          delta = last_delta(gesture_buffer, status)
 
           repeat_direction = Direction.new(move_x: delta.move_x, move_y: delta.move_y).to_s
           repeat_quantity = Quantity.new(move_x: delta.move_x, move_y: delta.move_y).to_f

--- a/lib/fusuma/plugin/detectors/swipe_detector.rb
+++ b/lib/fusuma/plugin/detectors/swipe_detector.rb
@@ -122,18 +122,6 @@ module Fusuma
           quantity > threshold(index: index)
         end
 
-        #: (index: Fusuma::Config::Index) -> Integer
-        def threshold(index:)
-          @threshold ||= {}
-          @threshold[index.cache_key] ||= begin
-            keys_specific = Config::Index.new [*index.keys, "threshold"]
-            keys_global = Config::Index.new ["threshold", type]
-            config_value = Config.search(keys_specific) ||
-              Config.search(keys_global) || 1
-            BASE_THRESHOLD * config_value
-          end
-        end
-
         # direction of gesture
         class Direction
           RIGHT = "right"

--- a/lib/fusuma/plugin/events/records/context_record.rb
+++ b/lib/fusuma/plugin/events/records/context_record.rb
@@ -11,12 +11,14 @@ module Fusuma
 
           # @param name [#to_sym]
           # @param value [String]
+          #: (name: String, value: String) -> void
           def initialize(name:, value:)
             super()
             @name = name.to_sym
             @value = value
           end
 
+          #: () -> Symbol
           def type
             :context
           end

--- a/lib/fusuma/plugin/events/records/index_record.rb
+++ b/lib/fusuma/plugin/events/records/index_record.rb
@@ -23,6 +23,7 @@ module Fusuma
             @args = args
           end
 
+          #: () -> String
           def to_s
             "#{@index}, #{@position}, #{@trigger}, #{@args}"
           end
@@ -36,6 +37,7 @@ module Fusuma
           # @param records [Array<IndexRecord>]
           # @return [IndexRecord] when merge is succeeded
           # @return [NilClass] when merge is not succeeded
+          #: (records: Array[untyped], ?index: Fusuma::Config::Index) -> Fusuma::Plugin::Events::Records::IndexRecord?
           def merge(records:, index: @index)
             # FIXME: cache
             raise "position is NOT body: #{self}" unless mergeable?
@@ -62,11 +64,13 @@ module Fusuma
           end
 
           # @param [Config::Searcher] searcher
+          #: (?Fusuma::Config::Index) -> (String | Hash[untyped, untyped] | Integer | Float)?
           def exist_on_conf?(index = @index)
             Config.search(index)
           end
 
           # @return [Integer]
+          #: () -> Integer
           def trigger_priority
             case @trigger
             when :oneshot
@@ -78,6 +82,7 @@ module Fusuma
             end
           end
 
+          #: () -> bool
           def mergeable?
             @position == :body
           end

--- a/lib/fusuma/plugin/executors/command_executor.rb
+++ b/lib/fusuma/plugin/executors/command_executor.rb
@@ -9,6 +9,7 @@ module Fusuma
       class CommandExecutor < Executor
         # Executor parameter on config.yml
         # @return [Array<Symbol>]
+        #: () -> Array[Symbol]
         def execute_keys
           [:command]
         end

--- a/lib/fusuma/plugin/executors/executor.rb
+++ b/lib/fusuma/plugin/executors/executor.rb
@@ -13,7 +13,7 @@ module Fusuma
 
         # Executor parameter on config.yml
         # @return [Array<Symbol>]
-        #: () -> nil
+        #: () -> Array[Symbol]
         def execute_keys
           # [name.split('Executors::').last.underscore.gsub('_executor', '').to_sym]
           raise NotImplementedError, "override #{self.class.name}##{__method__}"
@@ -22,7 +22,7 @@ module Fusuma
         # check executable
         # @param _event [Events::Event]
         # @return [TrueClass, FalseClass]
-        #: (String) -> nil
+        #: (Fusuma::Plugin::Events::Event) -> bool
         def executable?(_event)
           raise NotImplementedError, "override #{self.class.name}##{__method__}"
         end
@@ -62,7 +62,7 @@ module Fusuma
         # execute something
         # @param _event [Event]
         # @return [nil]
-        #: (String) -> nil
+        #: (Fusuma::Plugin::Events::Event) -> void
         def execute(_event)
           raise NotImplementedError, "override #{self.class.name}##{__method__}"
         end

--- a/lib/fusuma/plugin/inputs/input.rb
+++ b/lib/fusuma/plugin/inputs/input.rb
@@ -35,7 +35,7 @@ module Fusuma
         # so input plugin must write line to pipe (include `\n`)
         # or, override read_from_io and implement your own read method
         #: () -> String
-        def read_from_io
+        def read_from_io # steep:ignore MethodBodyTypeMismatch
           io.readline(chomp: true)
         rescue EOFError => e
           MultiLogger.error "#{self.class.name}: #{e}"
@@ -47,7 +47,7 @@ module Fusuma
         end
 
         # @return [IO]
-        #: () -> nil
+        #: () -> IO
         def io
           raise NotImplementedError, "override #{self.class.name}##{__method__}"
         end

--- a/lib/fusuma/plugin/inputs/libinput_command_input.rb
+++ b/lib/fusuma/plugin/inputs/libinput_command_input.rb
@@ -24,7 +24,7 @@ module Fusuma
         end
 
         # @return [IO]
-        #: () -> StringIO
+        #: () -> IO
         def io
           @io ||= begin
             reader, writer = create_io

--- a/lib/fusuma/plugin/inputs/timer_input.rb
+++ b/lib/fusuma/plugin/inputs/timer_input.rb
@@ -12,9 +12,10 @@ module Fusuma
 
         DEFAULT_INTERVAL = 5
         EPSILON_TIME = 0.02
+        #: () -> Hash[untyped, untyped]
         def config_param_types
           {
-            interval: [Float]
+            interval: [Float, Integer]
           }
         end
 

--- a/lib/fusuma/plugin/manager.rb
+++ b/lib/fusuma/plugin/manager.rb
@@ -44,8 +44,6 @@ module Fusuma
             raise "Not Found: #{match_data[1]}/#{match_data[2]}/*.gemspec" unless plugin_gemspec_path
 
             plugin_gemspec = Gem::Specification.load(plugin_gemspec_path)
-            fusuma_gemspec_path = File.expand_path("../../../fusuma.gemspec", __dir__ || ".")
-            fusuma_gemspec = Gem::Specification.load(fusuma_gemspec_path)
             next if plugin_gemspec == fusuma_gemspec
 
             if plugin_gemspec.dependencies.find { |d| d.name == "fusuma" }&.match?(fusuma_gemspec)
@@ -76,6 +74,12 @@ module Fusuma
       #: () -> String
       def plugin_dir_name
         @plugin_class.name.match(/(Fusuma::.*)::/)[1].to_s.underscore
+      end
+
+      # @return [Gem::Specification, nil] gemspec of running fusuma
+      #: () -> Gem::Specification?
+      def fusuma_gemspec
+        @fusuma_gemspec ||= Gem::Specification.load(File.expand_path("../../../fusuma.gemspec", __dir__ || "."))
       end
 
       class << self

--- a/lib/fusuma/plugin/parsers/libinput_gesture_parser.rb
+++ b/lib/fusuma/plugin/parsers/libinput_gesture_parser.rb
@@ -22,6 +22,8 @@ module Fusuma
             return
           end
 
+          return if gesture.nil?
+
           Events::Records::GestureRecord.new(status: status,
             gesture: gesture,
             finger: finger,
@@ -49,9 +51,9 @@ module Fusuma
         #: (String) -> Array[untyped]
         def parse_line(line)
           _device, event_name, _time, other = line.strip.split(nil, 4)
-          finger, other = other.split(nil, 2)
+          return [] unless event_name && other
 
-          return [] unless event_name
+          finger, other = other.split(nil, 2)
           gesture, status = *detect_gesture(event_name)
 
           status = "cancelled" if gesture == "hold" && status == "end" && other == "cancelled"
@@ -62,14 +64,14 @@ module Fusuma
         #: (String) -> Array[untyped]
         def parse_line_1_27_0_or_later(line)
           _device, event_name, other = line.strip.split(nil, 3)
+          return [] unless event_name && other
 
           if other[0] != "+"
             _seq, other = other.split(nil, 2)
+            return [] unless other
           end
 
           _time, finger, other = other.split(nil, 3)
-
-          return [] unless event_name
           gesture, status = *detect_gesture(event_name)
 
           status = "cancelled" if gesture == "hold" && status == "end" && other == "cancelled"
@@ -79,7 +81,8 @@ module Fusuma
 
         #: (String) -> Array[untyped]
         def detect_gesture(event_name)
-          event_name =~ /GESTURE_(SWIPE|PINCH|HOLD)_(BEGIN|UPDATE|END)/
+          return [] unless event_name =~ /GESTURE_(SWIPE|PINCH|HOLD)_(BEGIN|UPDATE|END)/
+
           gesture = Regexp.last_match(1).downcase
           status = Regexp.last_match(2).downcase
           [gesture, status]

--- a/lib/fusuma/string_support.rb
+++ b/lib/fusuma/string_support.rb
@@ -2,6 +2,7 @@
 
 # support camerize and underscore
 class String
+  #: () -> String
   def camelize
     split("_").map(&:capitalize).join
   end

--- a/sig/generated/lib/fusuma/config.rbs
+++ b/sig/generated/lib/fusuma/config.rbs
@@ -13,7 +13,8 @@ module Fusuma
     # : (Fusuma::Config::Index) -> (String | Hash[untyped, untyped] | Integer | Float)?
     def self.search: (Fusuma::Config::Index) -> (String | Hash[untyped, untyped] | Integer | Float)?
 
-    def self.find_execute_key: (untyped index) -> untyped
+    # : (Fusuma::Config::Index) -> Symbol?
+    def self.find_execute_key: (Fusuma::Config::Index) -> Symbol?
 
     # : (String?) -> Fusuma::Config
     def self.custom_path=: (String?) -> Fusuma::Config
@@ -51,7 +52,8 @@ module Fusuma
 
     # @param index [Config::Index]
     # @return Symbol
-    def find_execute_key: (untyped index) -> untyped
+    # : (Fusuma::Config::Index) -> Symbol?
+    def find_execute_key: (Fusuma::Config::Index) -> Symbol?
 
     private
 
@@ -64,7 +66,8 @@ module Fusuma
     # : (String) -> String
     def expand_config_path: (String) -> String
 
-    def expand_default_path: (untyped filename) -> untyped
+    # : (String) -> String
+    def expand_default_path: (String) -> String
 
     # : () -> Array[untyped]
     def plugin_defaults_paths: () -> Array[untyped]

--- a/sig/generated/lib/fusuma/config/index.rbs
+++ b/sig/generated/lib/fusuma/config/index.rbs
@@ -10,7 +10,8 @@ module Fusuma
 
       attr_reader cache_key: Symbol | Integer
 
-      def to_s: () -> untyped
+      # : () -> Array[untyped]
+      def to_s: () -> Array[untyped]
 
       def ==: (untyped other) -> untyped
 

--- a/sig/generated/lib/fusuma/config/searcher.rbs
+++ b/sig/generated/lib/fusuma/config/searcher.rbs
@@ -34,7 +34,7 @@ module Fusuma
       #  1. look up location with key
       #  2. skip the key and go to child location
       # : (Hash[untyped, untyped], Fusuma::Config::Index::Key) -> Array[untyped]
-      def next_location_cadidates: (Hash[untyped, untyped], Fusuma::Config::Index::Key) -> Array[untyped]
+      def next_location_candidates: (Hash[untyped, untyped], Fusuma::Config::Index::Key) -> Array[untyped]
 
       attr_reader context: untyped
 

--- a/sig/generated/lib/fusuma/hash_support.rbs
+++ b/sig/generated/lib/fusuma/hash_support.rbs
@@ -2,12 +2,17 @@
 # @rbs generic unchecked out V
 class Hash[unchecked out K, unchecked out V]
   # activesupport-5.2.0/lib/active_support/core_ext/hash/deep_merge.rb
+  # Keep untyped: rbs-trace would record concrete types here that conflict
+  # with the block type of the core Hash#merge! signature under steep.
+  # : (untyped other_hash) ?{ (?) -> untyped } -> untyped
   def deep_merge: (untyped other_hash) ?{ (?) -> untyped } -> untyped
 
   # Same as +deep_merge+, but modifies +self+.
+  # : (untyped other_hash) ?{ (?) -> untyped } -> untyped
   def deep_merge!: (untyped other_hash) ?{ (?) -> untyped } -> untyped
 
-  def deep_stringify_keys: () -> untyped
+  # : () -> Hash[untyped, untyped]
+  def deep_stringify_keys: () -> Hash[untyped, untyped]
 
   # activesupport-4.1.1/lib/active_support/core_ext/hash/keys.rb
   # : () -> Hash[Symbol, untyped]

--- a/sig/generated/lib/fusuma/libinput_command.rbs
+++ b/sig/generated/lib/fusuma/libinput_command.rbs
@@ -13,24 +13,25 @@ module Fusuma
     def new_cli_option_available?: () -> bool
 
     # @return [Boolean]
-    def libinput_1_27_0_or_later?: () -> untyped
+    # : () -> bool
+    def libinput_1_27_0_or_later?: () -> bool
 
     # @return [String]
-    # : () -> String?
-    def version: () -> String?
+    # : () -> String
+    def version: () -> String
 
     # @yieldparam [String] gives a line in libinput list-devices output to the block
     # : () { (String) -> void } -> void
     def list_devices: () { (String) -> void } -> void
 
     # @return [Integer] return a latest line libinput debug-events
-    # : (StringIO) -> Array[untyped]
-    def debug_events: (StringIO) -> Array[untyped]
+    # : (IO) -> Array[untyped]
+    def debug_events: (IO) -> Array[untyped]
 
     # @return [String] command
     # @raise [SystemExit]
-    # : () -> String?
-    def version_command: () -> String?
+    # : () -> String
+    def version_command: () -> String
 
     # : () -> String
     def list_devices_command: () -> String
@@ -49,6 +50,7 @@ module Fusuma
     #
     #   which('ruby') #=> /usr/bin/ruby
     # @return [String, nil]
-    def which: (untyped command) -> untyped
+    # : (String) -> String?
+    def which: (String) -> String?
   end
 end

--- a/sig/generated/lib/fusuma/multi_logger.rbs
+++ b/sig/generated/lib/fusuma/multi_logger.rbs
@@ -4,9 +4,13 @@ module Fusuma
   class MultiLogger < Logger
     include Singleton
 
+    DEFAULT_IGNORE_PATTERN: Regexp
+
     attr_reader err_logger: untyped
 
     attr_accessor debug_mode: untyped
+
+    attr_accessor ignore_pattern: Regexp
 
     attr_writer filepath: untyped
 
@@ -39,7 +43,7 @@ module Fusuma
 
     private
 
-    # : (String) -> bool
-    def ignore_pattern?: (String) -> bool
+    # : (untyped) -> bool
+    def ignore_pattern?: (untyped) -> bool
   end
 end

--- a/sig/generated/lib/fusuma/plugin/buffers/gesture_buffer.rbs
+++ b/sig/generated/lib/fusuma/plugin/buffers/gesture_buffer.rbs
@@ -62,7 +62,8 @@ module Fusuma
         #  event_buffer.gesture
         #  => 'swipe'
         # @return [String]
-        def gesture: () -> untyped
+        # : () -> String
+        def gesture: () -> String
 
         # : (String) -> Fusuma::Plugin::Buffers::GestureBuffer
         def select_by_type: (String) -> Fusuma::Plugin::Buffers::GestureBuffer

--- a/sig/generated/lib/fusuma/plugin/buffers/timer_buffer.rbs
+++ b/sig/generated/lib/fusuma/plugin/buffers/timer_buffer.rbs
@@ -7,14 +7,16 @@ module Fusuma
 
         DEFAULT_SECONDS_TO_KEEP: ::Integer
 
-        def config_param_types: () -> untyped
+        # : () -> Hash[untyped, untyped]
+        def config_param_types: () -> Hash[untyped, untyped]
 
         # @param event [Event]
         # @return [Buffer, NilClass]
         # : (Fusuma::Plugin::Events::Event) -> Fusuma::Plugin::Buffers::TimerBuffer?
         def buffer: (Fusuma::Plugin::Events::Event) -> Fusuma::Plugin::Buffers::TimerBuffer?
 
-        def clear_expired: (?current_time: untyped) -> untyped
+        # : (?current_time: Time) -> void
+        def clear_expired: (?current_time: Time) -> void
       end
     end
   end

--- a/sig/generated/lib/fusuma/plugin/detectors/detector.rbs
+++ b/sig/generated/lib/fusuma/plugin/detectors/detector.rbs
@@ -37,6 +37,13 @@ module Fusuma
 
         # : () -> bool
         def first_time?: () -> bool
+
+        private
+
+        # @param index [Config::Index]
+        # @return [Float, Integer]
+        # : (index: Fusuma::Config::Index) -> (Float | Integer)
+        def threshold: (index: Fusuma::Config::Index) -> (Float | Integer)
       end
     end
   end

--- a/sig/generated/lib/fusuma/plugin/detectors/detector.rbs
+++ b/sig/generated/lib/fusuma/plugin/detectors/detector.rbs
@@ -37,6 +37,22 @@ module Fusuma
 
         # : () -> bool
         def first_time?: () -> bool
+
+        private
+
+        # Detect the current status of the gesture from the buffer
+        # @param gesture_buffer [Buffers::GestureBuffer]
+        # @param updating_events [Array<Events::Event>]
+        # @return [String] "begin", "update", "end", or the last record's status
+        # : (untyped, Array[untyped]) -> String
+        def detect_status: (untyped, Array[untyped]) -> String
+
+        # Select the delta of the last relevant event depending on the status
+        # @param gesture_buffer [Buffers::GestureBuffer]
+        # @param status [String]
+        # @return [Events::Records::GestureRecord::Delta]
+        # : (untyped, String) -> untyped
+        def last_delta: (untyped, String) -> untyped
       end
     end
   end

--- a/sig/generated/lib/fusuma/plugin/detectors/hold_detector.rbs
+++ b/sig/generated/lib/fusuma/plugin/detectors/hold_detector.rbs
@@ -43,9 +43,6 @@ module Fusuma
 
         # : (index: Fusuma::Config::Index, holding_time: Float) -> bool
         def enough?: (index: Fusuma::Config::Index, holding_time: Float) -> bool
-
-        # : (index: Fusuma::Config::Index) -> Float
-        def threshold: (index: Fusuma::Config::Index) -> Float
       end
     end
   end

--- a/sig/generated/lib/fusuma/plugin/detectors/pinch_detector.rbs
+++ b/sig/generated/lib/fusuma/plugin/detectors/pinch_detector.rbs
@@ -41,9 +41,6 @@ module Fusuma
         # : (index: Fusuma::Config::Index, quantity: Float) -> bool
         def enough_oneshot_threshold?: (index: Fusuma::Config::Index, quantity: Float) -> bool
 
-        # : (index: Fusuma::Config::Index) -> Float
-        def threshold: (index: Fusuma::Config::Index) -> Float
-
         # direction of gesture
         class Direction
           IN: ::String

--- a/sig/generated/lib/fusuma/plugin/detectors/rotate_detector.rbs
+++ b/sig/generated/lib/fusuma/plugin/detectors/rotate_detector.rbs
@@ -41,9 +41,6 @@ module Fusuma
         # : (index: Fusuma::Config::Index, quantity: Float) -> bool
         def enough_oneshot_threshold?: (index: Fusuma::Config::Index, quantity: Float) -> bool
 
-        # : (index: Fusuma::Config::Index) -> Float
-        def threshold: (index: Fusuma::Config::Index) -> Float
-
         # direction of gesture
         class Direction
           CLOCKWISE: ::String

--- a/sig/generated/lib/fusuma/plugin/detectors/swipe_detector.rbs
+++ b/sig/generated/lib/fusuma/plugin/detectors/swipe_detector.rbs
@@ -41,9 +41,6 @@ module Fusuma
         # : (index: Fusuma::Config::Index, quantity: Float) -> bool
         def enough_oneshot_threshold?: (index: Fusuma::Config::Index, quantity: Float) -> bool
 
-        # : (index: Fusuma::Config::Index) -> Integer
-        def threshold: (index: Fusuma::Config::Index) -> Integer
-
         # direction of gesture
         class Direction
           RIGHT: ::String

--- a/sig/generated/lib/fusuma/plugin/events/records/context_record.rbs
+++ b/sig/generated/lib/fusuma/plugin/events/records/context_record.rbs
@@ -12,9 +12,11 @@ module Fusuma
 
           # @param name [#to_sym]
           # @param value [String]
-          def initialize: (name: untyped, value: untyped) -> untyped
+          # : (name: String, value: String) -> void
+          def initialize: (name: String, value: String) -> void
 
-          def type: () -> untyped
+          # : () -> Symbol
+          def type: () -> Symbol
         end
       end
     end

--- a/sig/generated/lib/fusuma/plugin/events/records/index_record.rbs
+++ b/sig/generated/lib/fusuma/plugin/events/records/index_record.rbs
@@ -20,7 +20,8 @@ module Fusuma
           # : (index: Fusuma::Config::Index, ?position: Symbol, ?trigger: Symbol, ?args: Hash[untyped, untyped]) -> void
           def initialize: (index: Fusuma::Config::Index, ?position: Symbol, ?trigger: Symbol, ?args: Hash[untyped, untyped]) -> void
 
-          def to_s: () -> untyped
+          # : () -> String
+          def to_s: () -> String
 
           # : () -> Symbol
           def type: () -> Symbol
@@ -29,15 +30,19 @@ module Fusuma
           # @param records [Array<IndexRecord>]
           # @return [IndexRecord] when merge is succeeded
           # @return [NilClass] when merge is not succeeded
-          def merge: (records: untyped, ?index: untyped) -> untyped
+          # : (records: Array[untyped], ?index: Fusuma::Config::Index) -> Fusuma::Plugin::Events::Records::IndexRecord?
+          def merge: (records: Array[untyped], ?index: Fusuma::Config::Index) -> Fusuma::Plugin::Events::Records::IndexRecord?
 
           # @param [Config::Searcher] searcher
-          def exist_on_conf?: (?untyped index) -> untyped
+          # : (?Fusuma::Config::Index) -> (String | Hash[untyped, untyped] | Integer | Float)?
+          def exist_on_conf?: (?Fusuma::Config::Index) -> (String | Hash[untyped, untyped] | Integer | Float)?
 
           # @return [Integer]
-          def trigger_priority: () -> untyped
+          # : () -> Integer
+          def trigger_priority: () -> Integer
 
-          def mergeable?: () -> untyped
+          # : () -> bool
+          def mergeable?: () -> bool
         end
       end
     end

--- a/sig/generated/lib/fusuma/plugin/executors/command_executor.rbs
+++ b/sig/generated/lib/fusuma/plugin/executors/command_executor.rbs
@@ -5,7 +5,8 @@ module Fusuma
       class CommandExecutor < Executor
         # Executor parameter on config.yml
         # @return [Array<Symbol>]
-        def execute_keys: () -> untyped
+        # : () -> Array[Symbol]
+        def execute_keys: () -> Array[Symbol]
 
         # : (Fusuma::Plugin::Events::Event) -> void
         def execute: (Fusuma::Plugin::Events::Event) -> void

--- a/sig/generated/lib/fusuma/plugin/executors/executor.rbs
+++ b/sig/generated/lib/fusuma/plugin/executors/executor.rbs
@@ -10,14 +10,14 @@ module Fusuma
 
         # Executor parameter on config.yml
         # @return [Array<Symbol>]
-        # : () -> nil
-        def execute_keys: () -> nil
+        # : () -> Array[Symbol]
+        def execute_keys: () -> Array[Symbol]
 
         # check executable
         # @param _event [Events::Event]
         # @return [TrueClass, FalseClass]
-        # : (String) -> nil
-        def executable?: (String) -> nil
+        # : (Fusuma::Plugin::Events::Event) -> bool
+        def executable?: (Fusuma::Plugin::Events::Event) -> bool
 
         # @param event [Events::Event]
         # @return [TrueClass, FalseClass]
@@ -33,8 +33,8 @@ module Fusuma
         # execute something
         # @param _event [Event]
         # @return [nil]
-        # : (String) -> nil
-        def execute: (String) -> nil
+        # : (Fusuma::Plugin::Events::Event) -> void
+        def execute: (Fusuma::Plugin::Events::Event) -> void
       end
     end
   end

--- a/sig/generated/lib/fusuma/plugin/inputs/input.rbs
+++ b/sig/generated/lib/fusuma/plugin/inputs/input.rbs
@@ -23,8 +23,8 @@ module Fusuma
         def read_from_io: () -> String
 
         # @return [IO]
-        # : () -> nil
-        def io: () -> nil
+        # : () -> IO
+        def io: () -> IO
 
         # @return [Event]
         # : (?record: String) -> Fusuma::Plugin::Events::Event

--- a/sig/generated/lib/fusuma/plugin/inputs/libinput_command_input.rbs
+++ b/sig/generated/lib/fusuma/plugin/inputs/libinput_command_input.rbs
@@ -7,8 +7,8 @@ module Fusuma
         def config_param_types: () -> Hash[Symbol, Array[Class]]
 
         # @return [IO]
-        # : () -> StringIO
-        def io: () -> StringIO
+        # : () -> IO
+        def io: () -> IO
 
         # @return [LibinputCommand]
         # : () -> (Fusuma::LibinputCommand)

--- a/sig/generated/lib/fusuma/plugin/inputs/timer_input.rbs
+++ b/sig/generated/lib/fusuma/plugin/inputs/timer_input.rbs
@@ -9,7 +9,8 @@ module Fusuma
 
         EPSILON_TIME: ::Float
 
-        def config_param_types: () -> untyped
+        # : () -> Hash[untyped, untyped]
+        def config_param_types: () -> Hash[untyped, untyped]
 
         # : (*nil, ?interval: nil) -> void
         def initialize: (*nil, ?interval: nil) -> void

--- a/sig/generated/lib/fusuma/plugin/manager.rbs
+++ b/sig/generated/lib/fusuma/plugin/manager.rbs
@@ -37,6 +37,10 @@ module Fusuma
       # : () -> String
       def plugin_dir_name: () -> String
 
+      # @return [Gem::Specification, nil] gemspec of running fusuma
+      # : () -> Gem::Specification?
+      def fusuma_gemspec: () -> Gem::Specification?
+
       # Register a plugin class with the manager.
       # @param plugin_class [Class] the plugin class to register
       # @param plugin_path [String] the file path of the plugin

--- a/sig/generated/lib/fusuma/string_support.rbs
+++ b/sig/generated/lib/fusuma/string_support.rbs
@@ -1,6 +1,7 @@
 # support camerize and underscore
 class String
-  def camelize: () -> untyped
+  # : () -> String
+  def camelize: () -> String
 
   # : () -> String
   def underscore: () -> String

--- a/sig/prototype/lib/fusuma/plugin/detectors/detector.rbs
+++ b/sig/prototype/lib/fusuma/plugin/detectors/detector.rbs
@@ -6,6 +6,8 @@ module Fusuma
         @sources: untyped
 
         @last_time: untyped
+
+        @threshold: untyped
       end
     end
   end

--- a/sig/prototype/lib/fusuma/plugin/detectors/hold_detector.rbs
+++ b/sig/prototype/lib/fusuma/plugin/detectors/hold_detector.rbs
@@ -6,8 +6,6 @@ module Fusuma
         @timer: untyped
 
         @timeout: untyped
-
-        @threshold: untyped
       end
     end
   end

--- a/sig/prototype/lib/fusuma/plugin/detectors/pinch_detector.rbs
+++ b/sig/prototype/lib/fusuma/plugin/detectors/pinch_detector.rbs
@@ -15,7 +15,6 @@ module Fusuma
 
           @base: untyped
         end
-        @threshold: untyped
       end
     end
   end

--- a/sig/prototype/lib/fusuma/plugin/detectors/rotate_detector.rbs
+++ b/sig/prototype/lib/fusuma/plugin/detectors/rotate_detector.rbs
@@ -11,7 +11,6 @@ module Fusuma
         class Quantity
           @angle: untyped
         end
-        @threshold: untyped
       end
     end
   end

--- a/sig/prototype/lib/fusuma/plugin/detectors/swipe_detector.rbs
+++ b/sig/prototype/lib/fusuma/plugin/detectors/swipe_detector.rbs
@@ -15,7 +15,6 @@ module Fusuma
 
           @y: untyped
         end
-        @threshold: untyped
       end
     end
   end

--- a/sig/prototype/lib/fusuma/plugin/manager.rbs
+++ b/sig/prototype/lib/fusuma/plugin/manager.rbs
@@ -13,6 +13,8 @@ module Fusuma
       @_fusuma_default_plugin_paths: untyped
 
       @_fusuma_external_plugin_paths: untyped
+
+      @fusuma_gemspec: untyped
     end
   end
 end

--- a/spec/fusuma/config/searcher_spec.rb
+++ b/spec/fusuma/config/searcher_spec.rb
@@ -7,8 +7,8 @@ require "./lib/fusuma/config/searcher"
 # spec for Config
 module Fusuma
   RSpec.describe Config::Searcher do
-    around do |example|
-      ConfigHelper.load_config_yml = <<~CONFIG
+    let(:config_yml) do
+      <<~CONFIG
         swipe:
           3:
             left:
@@ -26,6 +26,10 @@ module Fusuma
           out:
             command: 'ctrl+minus'
       CONFIG
+    end
+
+    around do |example|
+      ConfigHelper.load_config_yml = config_yml
 
       example.run
 
@@ -95,8 +99,8 @@ module Fusuma
         end
 
         context "with gesture lifecycle (begin/update/end)" do
-          around do |example|
-            ConfigHelper.load_config_yml = <<~CONFIG
+          let(:config_yml) do
+            <<~CONFIG
               swipe:
                 3:
                   begin:
@@ -109,8 +113,6 @@ module Fusuma
                       LEFTCTRL:
                         command: 'echo end+ctrl'
             CONFIG
-            example.run
-            ConfigHelper.clear_config_yml
           end
 
           context "without keypress modifier" do
@@ -165,8 +167,8 @@ module Fusuma
     end
 
     describe ".find_context" do
-      around do |example|
-        ConfigHelper.load_config_yml = <<~CONFIG
+      let(:config_yml) do
+        <<~CONFIG
           ---
           context: { plugin_defaults: "libinput_command_input" }
           plugin:
@@ -179,10 +181,6 @@ module Fusuma
               sendkey_executor:
                 device_name: keyboard|Keyboard|KEYBOARD
         CONFIG
-
-        example.run
-
-        ConfigHelper.clear_config_yml
       end
 
       it "should find matched context and matched value" do
@@ -200,8 +198,8 @@ module Fusuma
       end
 
       context "with OR condition (array value)" do
-        around do |example|
-          ConfigHelper.load_config_yml = <<~CONFIG
+        let(:config_yml) do
+          <<~CONFIG
             ---
             context:
               application:
@@ -212,8 +210,6 @@ module Fusuma
                 left:
                   command: 'browser-back'
           CONFIG
-          example.run
-          ConfigHelper.clear_config_yml
         end
 
         it "matches when request value is in the array" do
@@ -242,8 +238,8 @@ module Fusuma
       end
 
       context "with AND + OR condition" do
-        around do |example|
-          ConfigHelper.load_config_yml = <<~CONFIG
+        let(:config_yml) do
+          <<~CONFIG
             ---
             context:
               thumbsense: true
@@ -253,8 +249,6 @@ module Fusuma
             remap:
               H: 'alt+Left'
           CONFIG
-          example.run
-          ConfigHelper.clear_config_yml
         end
 
         it "matches when both AND and OR conditions are satisfied" do
@@ -283,8 +277,8 @@ module Fusuma
       end
 
       context "with same application in multiple context blocks (OR and single)" do
-        around do |example|
-          ConfigHelper.load_config_yml = <<~CONFIG
+        let(:config_yml) do
+          <<~CONFIG
             ---
             context:
               application:
@@ -300,8 +294,6 @@ module Fusuma
                 left:
                   sendkey: "LEFTALT+RIGHT"
           CONFIG
-          example.run
-          ConfigHelper.clear_config_yml
         end
 
         it "finds remap config for Google-chrome via OR condition" do
@@ -364,8 +356,8 @@ module Fusuma
       let(:searcher) { Config::Searcher.new }
 
       context "with no-context and context blocks" do
-        around do |example|
-          ConfigHelper.load_config_yml = <<~CONFIG
+        let(:config_yml) do
+          <<~CONFIG
             ---
             swipe:
               3:
@@ -381,8 +373,6 @@ module Fusuma
                 left:
                   command: 'browser-back'
           CONFIG
-          example.run
-          ConfigHelper.clear_config_yml
         end
 
         let(:location) { Config.instance.keymap }
@@ -423,15 +413,13 @@ module Fusuma
       end
 
       context "with no-context block only" do
-        around do |example|
-          ConfigHelper.load_config_yml = <<~CONFIG
+        let(:config_yml) do
+          <<~CONFIG
             swipe:
               3:
                 left:
                   command: 'default-back'
           CONFIG
-          example.run
-          ConfigHelper.clear_config_yml
         end
 
         let(:location) { Config.instance.keymap }
@@ -444,8 +432,8 @@ module Fusuma
       end
 
       context "skipping no-context blocks when context is specified" do
-        around do |example|
-          ConfigHelper.load_config_yml = <<~CONFIG
+        let(:config_yml) do
+          <<~CONFIG
             ---
             remap:
               H: 'default-h'
@@ -455,8 +443,6 @@ module Fusuma
             remap:
               H: 'thumbsense-h'
           CONFIG
-          example.run
-          ConfigHelper.clear_config_yml
         end
 
         let(:location) { Config.instance.keymap }

--- a/spec/fusuma/config/yaml_duplication_checker_spec.rb
+++ b/spec/fusuma/config/yaml_duplication_checker_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "./lib/fusuma/config/yaml_duplication_checker"
+
+module Fusuma
+  RSpec.describe Config::YAMLDuplicationChecker do
+    describe ".check" do
+      def duplicates_in(yaml_string)
+        [].tap do |duplicates|
+          described_class.check(yaml_string, "fusuma_config.yml") do |exist, duplicated|
+            duplicates << [exist, duplicated]
+          end
+        end
+      end
+
+      context "with duplicated top-level keys" do
+        let(:yaml_string) do
+          <<~YAML
+            swipe:
+              3:
+                left:
+                  command: "command1"
+            swipe:
+              4:
+                left:
+                  command: "command2"
+          YAML
+        end
+
+        it "calls the block once with the existing and duplicated key nodes" do
+          duplicates = duplicates_in(yaml_string)
+
+          expect(duplicates.size).to eq(1)
+
+          exist, duplicated = duplicates.first
+          expect(exist).to be_a(Psych::Nodes::Scalar)
+          expect(duplicated).to be_a(Psych::Nodes::Scalar)
+          expect(exist.value).to eq("swipe")
+          expect(duplicated.value).to eq("swipe")
+          expect(exist.start_line).to be < duplicated.start_line
+        end
+      end
+
+      context "with duplicated keys in a nested mapping" do
+        let(:yaml_string) do
+          <<~YAML
+            swipe:
+              3:
+                left:
+                  command: "command1"
+                left:
+                  command: "command2"
+          YAML
+        end
+
+        it "detects the duplicated nested keys" do
+          duplicates = duplicates_in(yaml_string)
+
+          expect(duplicates.size).to eq(1)
+
+          exist, duplicated = duplicates.first
+          expect(exist.value).to eq("left")
+          expect(duplicated.value).to eq("left")
+          expect(exist.start_line).to be < duplicated.start_line
+        end
+      end
+
+      context "with same-named keys at different levels" do
+        let(:yaml_string) do
+          <<~YAML
+            swipe:
+              3:
+                left:
+                  command: "command1"
+              4:
+                left:
+                  command: "command2"
+          YAML
+        end
+
+        it "does not report them as duplicated" do
+          expect(duplicates_in(yaml_string)).to be_empty
+        end
+      end
+
+      context "without duplicated keys" do
+        let(:yaml_string) do
+          <<~YAML
+            swipe:
+              3:
+                left:
+                  command: "command1"
+                right:
+                  command: "command2"
+          YAML
+        end
+
+        it "does not call the block" do
+          expect(duplicates_in(yaml_string)).to be_empty
+        end
+      end
+
+      context "with an empty string" do
+        let(:yaml_string) { "" }
+
+        it "does not call the block" do
+          expect(duplicates_in(yaml_string)).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/fusuma/config_spec.rb
+++ b/spec/fusuma/config_spec.rb
@@ -44,6 +44,28 @@ module Fusuma
       end
     end
 
+    describe "#fetch_config_params" do
+      context "when the value resolved from the index is a scalar instead of a Hash" do
+        before do
+          ConfigHelper.load_config_yml = <<~CONFIG
+            plugin:
+              inputs:
+                libinput_command_input: "foo"
+          CONFIG
+        end
+
+        after { ConfigHelper.clear_config_yml }
+
+        it "returns an empty hash without raising an error" do
+          index = Config::Index.new(%w[plugin inputs libinput_command_input])
+          params = nil
+          expect { params = Config.instance.fetch_config_params(:enable_tap, index) }
+            .not_to raise_error
+          expect(params).to eq({})
+        end
+      end
+    end
+
     describe "#validate" do
       context "with valid yaml" do
         before do

--- a/spec/fusuma/hash_support_spec.rb
+++ b/spec/fusuma/hash_support_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "./lib/fusuma/hash_support"
+
+RSpec.describe Hash do
+  describe "#deep_merge" do
+    it "merges nested hashes recursively" do
+      receiver = {a: {b: 1, c: 2}, d: 3}
+      other = {a: {c: 20, e: 30}, f: 4}
+
+      expect(receiver.deep_merge(other)).to eq(a: {b: 1, c: 20, e: 30}, d: 3, f: 4)
+    end
+
+    it "does not modify the receiver" do
+      receiver = {a: {b: 1}}
+      receiver.deep_merge(a: {b: 2})
+
+      expect(receiver).to eq(a: {b: 1})
+    end
+
+    context "with a block" do
+      it "resolves conflicted keys with the block" do
+        receiver = {a: {b: 1}, c: 10}
+        other = {a: {b: 2}, c: 20}
+
+        result = receiver.deep_merge(other) { |_k, this_val, other_val| this_val + other_val }
+
+        expect(result).to eq(a: {b: 3}, c: 30)
+      end
+    end
+  end
+
+  describe "#deep_merge!" do
+    it "modifies the receiver" do
+      receiver = {a: {b: 1, c: 2}}
+      receiver.deep_merge!(a: {c: 20, e: 30})
+
+      expect(receiver).to eq(a: {b: 1, c: 20, e: 30})
+    end
+  end
+
+  describe "#deep_stringify_keys" do
+    it "converts nested keys to strings" do
+      hash = {a: {b: {c: 1}}, d: 2}
+
+      expect(hash.deep_stringify_keys).to eq("a" => {"b" => {"c" => 1}}, "d" => 2)
+    end
+  end
+
+  describe "#deep_symbolize_keys" do
+    it "converts nested string keys to symbols" do
+      hash = {"a" => {"b" => 1}, "c" => 2}
+
+      expect(hash.deep_symbolize_keys).to eq(a: {b: 1}, c: 2)
+    end
+
+    it "keeps keys that do not respond to to_sym" do
+      hash = {"a" => 1, 2 => 3}
+
+      expect(hash.deep_symbolize_keys).to eq({:a => 1, 2 => 3})
+    end
+  end
+
+  describe "#deep_transform_keys" do
+    it "transforms nested keys recursively" do
+      hash = {a: {b: {c: 1}}}
+
+      result = hash.deep_transform_keys { |key| key.to_s.upcase }
+
+      expect(result).to eq("A" => {"B" => {"C" => 1}})
+    end
+  end
+
+  describe "#deep_transform_values" do
+    it "transforms values in nested hashes" do
+      hash = {a: 1, b: {c: 2}}
+
+      expect(hash.deep_transform_values { |v| v * 10 }).to eq(a: 10, b: {c: 20})
+    end
+
+    it "transforms values inside arrays" do
+      hash = {a: [1, {b: 2}]}
+
+      expect(hash.deep_transform_values { |v| v * 10 }).to eq(a: [10, {b: 20}])
+    end
+  end
+end

--- a/spec/fusuma/libinput_command_spec.rb
+++ b/spec/fusuma/libinput_command_spec.rb
@@ -19,7 +19,7 @@ module Fusuma
             .with("libinput") { false }
           allow(libinput_command).to receive("which")
             .with("libinput-list-devices") { true }
-          allow_any_instance_of(Kernel).to receive(:`)
+          allow(libinput_command).to receive(:`)
             .with("libinput-list-devices --version") { "1.6.3\n" }
         end
 
@@ -33,7 +33,7 @@ module Fusuma
             .with("libinput") { true }
           allow(libinput_command).to receive("which")
             .with("libinput-list-devices") { false }
-          allow_any_instance_of(Kernel).to receive(:`)
+          allow(libinput_command).to receive(:`)
             .with("libinput --version") { "1.8\n" }
         end
 
@@ -76,7 +76,6 @@ module Fusuma
 
     describe "list_devices" do
       subject { libinput_command.list_devices }
-      after { subject }
 
       before do
         dummy_io = StringIO.new("dummy")
@@ -90,6 +89,7 @@ module Fusuma
 
         it "should call dummy events" do
           expect(Open3).to receive(:capture3).with(/dummy_list_devices/)
+          subject
         end
       end
 
@@ -102,6 +102,7 @@ module Fusuma
         it "call `libinput list-devices`" do
           command = "libinput list-devices"
           expect(Open3).to receive(:capture3).with(command)
+          subject
         end
       end
       context "with old cli version" do
@@ -113,6 +114,7 @@ module Fusuma
         it "call `libinput-list-devices`" do
           command = "libinput-list-devices"
           expect(Open3).to receive(:capture3).with(command)
+          subject
         end
       end
     end

--- a/spec/fusuma/multi_logger_spec.rb
+++ b/spec/fusuma/multi_logger_spec.rb
@@ -41,6 +41,41 @@ module Fusuma
         it "does not log debug messages that match the ignore pattern" do
           expect { MultiLogger.debug(ignored_message) }.not_to output(/#{ignored_message}/).to_stdout_from_any_process
         end
+
+        context "when ignore_pattern is customized" do
+          before do
+            MultiLogger.instance.ignore_pattern = /custom_tag/
+          end
+
+          it "does not log debug messages that match the custom pattern" do
+            expect { MultiLogger.debug("custom_tag message") }.not_to output.to_stdout_from_any_process
+          end
+
+          it "logs debug messages that match the default pattern" do
+            expect { MultiLogger.debug(ignored_message) }.to output(/#{ignored_message}/).to_stdout_from_any_process
+          end
+        end
+
+        context "when ignore_pattern is built from log_filter config value" do
+          it "ignores messages matching a pattern built from a single String" do
+            MultiLogger.instance.ignore_pattern = Regexp.union(Array("custom_tag").map(&:to_s))
+            expect { MultiLogger.debug("custom_tag message") }.not_to output.to_stdout_from_any_process
+          end
+
+          it "ignores messages matching a pattern built from an Array of Strings" do
+            filters = ["custom_tag", "another_tag"]
+            MultiLogger.instance.ignore_pattern = Regexp.union(Array(filters).map(&:to_s))
+            expect { MultiLogger.debug("custom_tag message") }.not_to output.to_stdout_from_any_process
+            expect { MultiLogger.debug("another_tag message") }.not_to output.to_stdout_from_any_process
+            expect { MultiLogger.debug(debug_message) }.to output(/#{debug_message}/).to_stdout_from_any_process
+          end
+        end
+      end
+    end
+
+    describe "#ignore_pattern" do
+      it "defaults to DEFAULT_IGNORE_PATTERN" do
+        expect(MultiLogger.instance.ignore_pattern).to eq(MultiLogger::DEFAULT_IGNORE_PATTERN)
       end
     end
 

--- a/spec/fusuma/plugin/buffers/gesture_buffer_spec.rb
+++ b/spec/fusuma/plugin/buffers/gesture_buffer_spec.rb
@@ -12,6 +12,11 @@ module Fusuma
     module Buffers
       RSpec.describe GestureBuffer do
         before do
+          # Ignore the user's local ~/.config/fusuma/config.yml so that specs
+          # always fall back to the bundled default config
+          allow(Config.instance).to receive(:expand_config_path).and_wrap_original { |method, filename| "#{method.call(filename)}.does_not_exist" }
+          Config.instance.reload if Config.instance.custom_path.nil?
+
           @buffer = GestureBuffer.new
           delta = Events::Records::GestureRecord::Delta.new(-1, 0, 0, 0, 0, 0)
           @event_generator = lambda { |time = nil, status = "update"|

--- a/spec/fusuma/plugin/buffers/gesture_buffer_spec.rb
+++ b/spec/fusuma/plugin/buffers/gesture_buffer_spec.rb
@@ -143,19 +143,55 @@ module Fusuma
         end
 
         describe "#sum_attrs" do
-          it "should calculate the sum of each attribute"
+          before do
+            allow(@buffer).to receive(:source).and_return("libinput_gesture_parser")
+          end
+
+          it "should calculate the sum of each attribute" do
+            3.times { @buffer.buffer(@event_generator.call) }
+            expect(@buffer.sum_attrs(:move_x)).to eq(-3.0)
+          end
+
+          it "should sum only update events (exclude begin/end)" do
+            @buffer.buffer(@event_generator.call(nil, "begin"))
+            2.times { @buffer.buffer(@event_generator.call) }
+            @buffer.buffer(@event_generator.call(nil, "end"))
+            expect(@buffer.sum_attrs(:move_x)).to eq(-2.0)
+          end
         end
 
         describe "#avg_attrs" do
-          it "should calculate the average of each attribute"
+          before do
+            allow(@buffer).to receive(:source).and_return("libinput_gesture_parser")
+          end
+
+          it "should calculate the average of each attribute" do
+            3.times { @buffer.buffer(@event_generator.call) }
+            expect(@buffer.avg_attrs(:move_x)).to eq(-1.0)
+          end
         end
 
         describe "#finger" do
-          it "should return number of fingers in gestures"
+          before do
+            allow(@buffer).to receive(:source).and_return("libinput_gesture_parser")
+          end
+
+          it "should return number of fingers in gestures" do
+            @buffer.buffer(@event_generator.call)
+            expect(@buffer.finger).to eq(3)
+            expect(@buffer.finger).to be_a(Integer)
+          end
         end
 
         describe "#gesture" do
-          it "should return string of gesture type"
+          before do
+            allow(@buffer).to receive(:source).and_return("libinput_gesture_parser")
+          end
+
+          it "should return string of gesture type" do
+            @buffer.buffer(@event_generator.call)
+            expect(@buffer.gesture).to eq("SWIPE")
+          end
         end
 
         describe "#empty?" do

--- a/spec/fusuma/plugin/buffers/timer_buffer_spec.rb
+++ b/spec/fusuma/plugin/buffers/timer_buffer_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "./lib/fusuma/plugin/events/event"
+require "./lib/fusuma/plugin/buffers/timer_buffer"
+
+module Fusuma
+  module Plugin
+    module Buffers
+      RSpec.describe TimerBuffer do
+        before do
+          @buffer = TimerBuffer.new
+        end
+
+        describe "#type" do
+          subject { @buffer.type }
+          it { is_expected.to eq "timer" }
+        end
+
+        describe "#buffer" do
+          it "should buffer event and return self" do
+            event = Events::Event.new(tag: "timer_input", record: "timer")
+            expect(@buffer.buffer(event)).to eq @buffer
+            expect(@buffer.events).to eq [event]
+          end
+
+          it "should NOT buffer event with unmatched tag" do
+            event = Events::Event.new(tag: "libinput_gesture_parser", record: "timer")
+            expect(@buffer.buffer(event)).to be_nil
+            expect(@buffer.events).to eq []
+          end
+        end
+
+        describe "#source" do
+          subject { @buffer.source }
+
+          it { is_expected.to eq TimerBuffer::DEFAULT_SOURCE }
+
+          context "with config" do
+            around do |example|
+              @source = "custom_timer_input"
+
+              ConfigHelper.load_config_yml = <<~CONFIG
+                plugin:
+                 buffers:
+                   timer_buffer:
+                     source: #{@source}
+              CONFIG
+
+              example.run
+
+              Config.custom_path = nil
+            end
+
+            it { is_expected.to eq @source }
+          end
+        end
+
+        describe "#clear_expired" do
+          before do
+            @now = Time.now
+            @old_event = Events::Event.new(time: @now - 5, tag: "timer_input", record: "timer")
+            @new_event = Events::Event.new(time: @now - 1, tag: "timer_input", record: "timer")
+            @buffer.buffer(@old_event)
+            @buffer.buffer(@new_event)
+          end
+
+          it "should clear events older than DEFAULT_SECONDS_TO_KEEP" do
+            @buffer.clear_expired(current_time: @now)
+            expect(@buffer.events).to eq [@new_event]
+          end
+
+          context "with seconds_to_keep configured" do
+            around do |example|
+              ConfigHelper.load_config_yml = <<~CONFIG
+                plugin:
+                 buffers:
+                   timer_buffer:
+                     seconds_to_keep: 10
+              CONFIG
+
+              example.run
+
+              Config.custom_path = nil
+            end
+
+            it "should keep events within configured seconds_to_keep" do
+              @buffer.clear_expired(current_time: @now)
+              expect(@buffer.events).to eq [@old_event, @new_event]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fusuma/plugin/detectors/hold_detector_spec.rb
+++ b/spec/fusuma/plugin/detectors/hold_detector_spec.rb
@@ -77,6 +77,16 @@ module Fusuma
             end
           end
 
+          context "with unexpected status" do
+            before do
+              buffer(create_hold_events(statuses: %w[begin update]))
+            end
+            it "raises RuntimeError with the unexpected status" do
+              expect { @detector.detect([@buffer, @timer_buffer]) }
+                .to raise_error(RuntimeError, /Unexpected Status:update/)
+            end
+          end
+
           context "with hold events and timer events" do
             context "with begin event and timer events" do
               before do

--- a/spec/fusuma/plugin/events/records/context_record_spec.rb
+++ b/spec/fusuma/plugin/events/records/context_record_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "./lib/fusuma/plugin/events/records/record"
+require "./lib/fusuma/plugin/events/records/context_record"
+
+module Fusuma
+  module Plugin
+    module Events
+      module Records
+        RSpec.describe ContextRecord do
+          let(:record) { described_class.new(name: "application", value: "Firefox") }
+
+          describe "#type" do
+            subject { record.type }
+            it { is_expected.to eq :context }
+          end
+
+          describe "#name" do
+            subject { record.name }
+            it "is converted to a Symbol" do
+              is_expected.to eq :application
+            end
+          end
+
+          describe "#value" do
+            subject { record.value }
+            it { is_expected.to eq "Firefox" }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fusuma/plugin/events/records/index_record_spec.rb
+++ b/spec/fusuma/plugin/events/records/index_record_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "./lib/fusuma/plugin/events/records/record"
+require "./lib/fusuma/plugin/events/records/index_record"
+require "./lib/fusuma/plugin/executors/command_executor"
+require "./lib/fusuma/config"
+
+module Fusuma
+  module Plugin
+    module Events
+      module Records
+        RSpec.describe IndexRecord do
+          let(:index) { Config::Index.new(["swipe", 3, "left"]) }
+          let(:record) { described_class.new(index: index) }
+
+          describe "#type" do
+            subject { record.type }
+            it { is_expected.to eq :index }
+          end
+
+          describe "#mergeable?" do
+            subject { record.mergeable? }
+
+            context "when position is :body (default)" do
+              it { is_expected.to be true }
+            end
+
+            context "when position is :surfix" do
+              let(:record) { described_class.new(index: index, position: :surfix) }
+              it { is_expected.to be false }
+            end
+          end
+
+          describe "#trigger_priority" do
+            subject { record.trigger_priority }
+
+            context "when trigger is :oneshot (default)" do
+              it { is_expected.to eq 10 }
+            end
+
+            context "when trigger is :repeat" do
+              let(:record) { described_class.new(index: index, trigger: :repeat) }
+              it { is_expected.to eq 100 }
+            end
+
+            context "when trigger is unknown" do
+              let(:record) { described_class.new(index: index, trigger: :dummy) }
+              it { is_expected.to eq 1000 }
+            end
+          end
+
+          describe "#to_s" do
+            subject { record.to_s }
+            it { is_expected.to eq "#{index}, body, oneshot, {}" }
+          end
+
+          describe "#merge" do
+            around do |example|
+              ConfigHelper.load_config_yml = <<~CONFIG
+                swipe:
+                  3:
+                    left:
+                      command: "echo 'swipe left'"
+                      keypress:
+                        LEFTCTRL:
+                          command: "echo 'LEFTCTRL + swipe left'"
+              CONFIG
+
+              example.run
+
+              Config.custom_path = nil
+            end
+
+            context "with no records" do
+              context "when the index has an executable command on config" do
+                it "returns self" do
+                  expect(record.merge(records: [])).to eq record
+                end
+              end
+
+              context "when the index does not exist on config" do
+                let(:index) { Config::Index.new(["swipe", 4, "left"]) }
+
+                it "returns nil" do
+                  expect(record.merge(records: [])).to be nil
+                end
+              end
+            end
+
+            context "with a surfix record" do
+              let(:surfix_record) do
+                described_class.new(
+                  index: Config::Index.new(%w[keypress LEFTCTRL]),
+                  position: :surfix
+                )
+              end
+
+              it "returns self with an index merged with the surfix record" do
+                merged = record.merge(records: [surfix_record])
+                expect(merged).to eq record
+                expect(merged.index.keys.map(&:symbol)).to eq [:swipe, 3, :left, :keypress, :LEFTCTRL]
+              end
+            end
+
+            context "when the record itself is not :body position" do
+              let(:record) { described_class.new(index: index, position: :surfix) }
+
+              it "raises an error" do
+                expect { record.merge(records: []) }.to raise_error(/position is NOT body/)
+              end
+            end
+
+            context "with a :prefix position record" do
+              let(:prefix_record) do
+                described_class.new(index: Config::Index.new(["keypress"]), position: :prefix)
+              end
+
+              it "raises an error" do
+                expect { record.merge(records: [prefix_record]) }.to raise_error(/invalid index position/)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fusuma/plugin/inputs/timer_input_spec.rb
+++ b/spec/fusuma/plugin/inputs/timer_input_spec.rb
@@ -31,6 +31,32 @@ module Fusuma
             @input.start(@dummy_read, @dummy_write)
           }
         end
+
+        describe "#config_params" do
+          context "with Integer interval in config.yml" do
+            around do |example|
+              ConfigHelper.load_config_yml = <<~CONFIG
+                plugin:
+                  inputs:
+                    timer_input:
+                      interval: 3
+              CONFIG
+
+              # TimerInput is a Singleton and memoizes @config_params,
+              # so reset the cache before and after this example
+              TimerInput.instance.instance_variable_set(:@config_params, {})
+
+              example.run
+
+              TimerInput.instance.instance_variable_set(:@config_params, {})
+              ConfigHelper.clear_config_yml
+            end
+
+            it "does not exit and returns the Integer value" do
+              expect(@input.config_params(:interval)).to eq 3
+            end
+          end
+        end
       end
     end
   end

--- a/spec/fusuma/plugin/parsers/libinput_gesture_parser_spec.rb
+++ b/spec/fusuma/plugin/parsers/libinput_gesture_parser_spec.rb
@@ -81,6 +81,19 @@ module Fusuma
                 expect(parser.parse(event.call).record.finger).to eq 3
               end
             end
+
+            context "with an incomplete line" do
+              let(:event) { Events::Event.new(tag: "libinput_command_input", record: "event9   GESTURE_SWIPE_BEGIN") }
+
+              it "does not raise an error" do
+                expect { parser.parse(event) }.not_to raise_error
+              end
+
+              it "returns the original event without a gesture record" do
+                expect(parser.parse(event).record).not_to be_a Events::Records::GestureRecord
+                expect(parser.parse(event)).to eq event
+              end
+            end
           end
 
           context "with libinput version 1.26.0 or earlier" do
@@ -156,6 +169,19 @@ module Fusuma
                 expect(parser.parse(event.call).record.finger).to eq 3
                 expect(parser.parse(event.call).record.finger).to eq 4
                 expect(parser.parse(event.call).record.finger).to eq 4
+              end
+            end
+
+            context "with an incomplete line" do
+              let(:event) { Events::Event.new(tag: "libinput_command_input", record: "event9   GESTURE_SWIPE_BEGIN") }
+
+              it "does not raise an error" do
+                expect { parser.parse(event) }.not_to raise_error
+              end
+
+              it "returns the original event without a gesture record" do
+                expect(parser.parse(event).record).not_to be_a Events::Records::GestureRecord
+                expect(parser.parse(event)).to eq event
               end
             end
           end

--- a/spec/fusuma/string_support_spec.rb
+++ b/spec/fusuma/string_support_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "./lib/fusuma/string_support"
+
+RSpec.describe String do
+  describe "#camelize" do
+    it "converts snake_case to CamelCase" do
+      expect("gesture_buffer".camelize).to eq "GestureBuffer"
+    end
+
+    it "capitalizes a single word" do
+      expect("swipe".camelize).to eq "Swipe"
+    end
+  end
+
+  describe "#underscore" do
+    it "converts a namespaced class name to a path" do
+      expect("Fusuma::Plugin::Buffers::GestureBuffer".underscore)
+        .to eq "fusuma/plugin/buffers/gesture_buffer"
+    end
+
+    it "separates consecutive uppercase letters followed by a word" do
+      expect("APIClient".underscore).to eq "api_client"
+    end
+
+    it "converts hyphens to underscores" do
+      expect("foo-bar".underscore).to eq "foo_bar"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR integrates 26 small, independent improvements, each implemented and verified in isolation (rspec + rubocop per change), then merged and re-verified together.

**Result: 319 examples, 0 failures, 1 pending** (from 264 examples / 5 failures / 5 pending) · `steep check` clean · rubocop clean · line coverage 96%

### Bug fixes
- `Config#fetch_config_params`: guard against scalar values from `Config.search` crashing with `NoMethodError` (with regression spec)
- `libinput_gesture_parser`: nil guards for incomplete `GESTURE` lines (no more `NoMethodError` / all-nil `GestureRecord`)
- `TimerInput`: accept `Integer` for `interval:` in config (was `Float` only, inconsistent with the Integer default)
- `hold_detector`: unexpected status now raises the intended `RuntimeError` instead of `NoMethodError`
- `Config::Searcher`: fix method name typo (`next_location_cadidates` → `next_location_candidates`)
- `Config#validate`: read the config file once and reuse the content for duplication check and YAML parsing

### Features / refactoring
- `MultiLogger`: `log_filter` config key to customize debug-log suppression (resolves the TODO at multi_logger.rb)
- `Plugin::Manager`: memoize fusuma gemspec loading (was re-loaded per plugin path)
- Detectors: deduplicate identical `threshold`, status detection, and delta selection into the `Detector` base class

### Tests
- New specs for `string_support`, `hash_support`, `TimerBuffer`, `YAMLDuplicationChecker`, `IndexRecord`, `ContextRecord` (+55 examples overall)
- `gesture_buffer_spec`: isolated from local `~/.config/fusuma/config.yml` (fixes 5 environment-dependent failures) and implemented 4 pending examples
- `libinput_command_spec`: replace `allow_any_instance_of(Kernel)` with instance-scoped stubs; DRY up `searcher_spec` around blocks

### RBS / typing
- Fix annotations for `LibinputCommand`, `Input#io` family, and `Executor` abstract methods (all verified with `rbs validate` + `steep check`)

### Docs / CI
- README: fix `--log` option, add `--show-config`, mention rotate in Threshold/Interval section
- CONTRIBUTING: Ruby 2.7+, standardrb reference, YARD instructions
- CI: add Ruby 3.4 to the test matrix; bump `actions/checkout` to v4 in gem-push.yml and minimize permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)